### PR TITLE
Use Launchpad as bug tracker, fixes #29

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -165,7 +165,7 @@
             <li class="p-navigation__link" role="menuitem">
               <a
                 class="p-link--external"
-                href="https://github.com/juju/juju/issues"
+                href="https://bugs.launchpad.net/juju/+bugs"
                 >Bugs</a
               >
             </li>


### PR DESCRIPTION
The Juju project doesn't use GitHub Issues to track bugs. This commit sends users to the correct place. 