### PR TITLE
Search juju.is/docs instead of docs.jujucharms.com

### DIFF
--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -57,6 +57,6 @@ def init_docs(app, url_prefix):
         "/docs/search",
         "docs-search",
         build_search_view(
-            site="docs.jujucharms.com", template_path="docs/search.html"
+            site="juju.is/docs", template_path="docs/search.html"
         ),
     )


### PR DESCRIPTION
QA
--

Get hold of the search API key from https://console.cloud.google.com/apis/credentials?project=ubuntu-search-1530889417216&pli=1, add it to `.env.local`:

```
echo "SEARCH_API_KEY={key}" >> .env.local
```

Now run the site with `./run`, go to `/docs`, search for something, see that all the results are on `juju.is`.