### PR TITLE
Pad pagination buttons

### DIFF
--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -34,38 +34,38 @@
       </div>
     </div>
 
-    {% if  results and results.entries %}
-        {% for item in results.entries %}
-        <div class="p-strip is-bordered is-shallow">
-          <div class="row">
-            <div class="col-12">
-              <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
-              <p>
-                {{ item.htmlSnippet | safe }}
-              </p>
-              <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
-            </div>
-          </div>
+    {% if results and results.entries %}
+    {% for item in results.entries %}
+    <div class="p-strip is-bordered is-shallow">
+      <div class="row">
+        <div class="col-12">
+          <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
+          <p>
+            {{ item.htmlSnippet | safe }}
+          </p>
+          <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
         </div>
-        {% endfor %}
-        <div class="p-strip p-pagination">
-            {% if  results.queries and results.queries.previousPage %}
-                <a
-                  class="p-pagination__link--previous"
-                  href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
-                >
-                    <span class="p-pagination__label">Previous</span>
-                </a>
-            {% endif %}
-            {% if results.queries and results.queries.nextPage %}
-              <a
-                class="p-pagination__link--next"
-                href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
-              >
-                <span class="p-pagination__label">Next</span>
-              </a>
-            {% endif %}
-        </div>
+      </div>
+    </div>
+    {% endfor %}
+    <div class="p-strip p-article-pagination">
+      {% if  results.queries and results.queries.previousPage %}
+      <a
+        class="p-article-pagination__link--previous"
+        href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+      >
+        <span class="p-article-pagination__label">Previous</span>
+      </a>
+      {% endif %}
+      {% if results.queries and results.queries.nextPage %}
+      <a
+        class="p-article-pagination__link--next"
+        href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+      >
+        <span class="p-article-pagination__label">Next</span>
+      </a>
+      {% endif %}
+    </div>
     {% else %}
     <div class="p-strip">
       <div class="row">

--- a/templates/index.html
+++ b/templates/index.html
@@ -373,10 +373,10 @@
             <a href="/docs/concepts-and-terms">Concepts</a>
           </li>
           <li class="p-list__item">
-            <a href="/tutorials" class="p-link--external">Tutorials</a>
+            <a href="/tutorials">Tutorials</a>
           </li>
           <li class="p-list__item">
-            <a href="/docs" class="p-link--external">Docs</a>
+            <a href="/docs">Docs</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done
- Update the pagination style of docs search results
- **Drive by** Remove external icon from internal links

## QA
- Pull the code
- Run `./run --env SEARCH_API_KEY=############` _ask someone in the team for the key_
- Go to /docs
- Search for something like "charm"
- Scroll to the bottom and see the pagination looks good and works as expected

## Details
Fixes https://github.com/canonical-web-and-design/juju.is/issues/35