### PR TITLE
Apply the navigation functionality to the small screen docs

### DIFF
--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -15,10 +15,24 @@
   </section>
   <div class="l-docs">
     <aside class="l-docs-sidebar" id="navigation">
-      <i class="p-sidenav__toggle p-icon--menu u-hide--medium u-hide--large"></i>
+      <a href="" class="p-sidenav__toggle p-icon--menu u-hide--medium u-hide--large"></a>
       <nav class="p-sidenav__body u-hide--small">
         {{ navigation | safe }}
       </nav>
+
+      <script>
+        document.addEventListener("DOMContentLoaded", function(event) {
+          // Toggle mobile sidebar nav
+          var toggle = document.querySelector('.p-sidenav__toggle');
+          var sidebarContent = document.querySelector('.p-sidenav__body');
+          toggle.addEventListener('click', function(e) {
+            e.preventDefault();
+            toggle.classList.toggle('p-icon--menu');
+            toggle.classList.toggle('p-icon--close');
+            sidebarContent.classList.toggle('u-hide--small');
+          });
+        });
+      </script>
     </aside>
     {% block content_docs %}{% endblock content_docs %}
   </div>

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -25,17 +25,6 @@
   // Set up highlightjs
   hljs.initHighlightingOnLoad();
 
-  document.addEventListener("DOMContentLoaded", function(event) {
-    // Toggle mobile sidebar nav
-    var toggle = document.querySelector('.p-sidenav__toggle');
-    var sidebarContent = document.querySelector('.p-sidenav__body');
-    toggle.addEventListener('click', function(e) {
-      toggle.classList.toggle('p-icon--menu');
-      toggle.classList.toggle('p-icon--close');
-      sidebarContent.classList.toggle('u-hide--small');
-    });
-  });
-
   // Add active links to active nav item and scroll to section
   var sidebar = document.querySelector(".l-docs-sidebar");
   document.querySelectorAll('.p-sidenav__body ul a').forEach(function(anchor) {


### PR DESCRIPTION
## Done
- Moved the JS the global template.
- Made the navigation toggle a link for a11y

## QA
- Go to /docs
- Shrink the screen to mobile size
- Click the navigation toggle
- Check it opens to reveal the navigation items
- Click a navigation item and check the navigation works on a document page too

Fixes https://github.com/canonical-web-and-design/juju.is/issues/42