### PR TITLE
Update discourse links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -152,8 +152,7 @@
             </li>
             <li class="p-navigation__link" role="menuitem">
               <a
-                class="p-link--external"
-                href="https://discourse.jujucharms.com"
+                href="https://discourse.juju.is"
                 >Discourse</a
               >
             </li>
@@ -200,7 +199,7 @@
                 <a class="p-link--inverted" href="/tutorials">Tutorials</a>
               </li>
               <li class="p-inline-list__item">
-                <a class="p-link--inverted p-link--external" href="https://discourse.jujucharms.com/">Discourse</a>
+                <a class="p-link--inverted" href="https://discourse.juju.is/">Discourse</a>
               </li>
               <li class="p-inline-list__item">
                 <a class="p-link--inverted" href="/docs/installing">Install Juju</a>

--- a/templates/docs/homepage.html
+++ b/templates/docs/homepage.html
@@ -87,7 +87,7 @@
           <h2>Contribute</h2>
           <ul class="p-list">
             <li class="p-list__item"><a class="p-link--external" href="https://github.com/juju/juju">Help improve Juju</a></li>
-            <li class="p-list__item--deep"><a class="p-link--external" href="https://discourse.jujucharms.com/t/documentation-guidelines/1245">Help improve the documentation</a></li>
+            <li class="p-list__item--deep"><a href="https://discourse.juju.is/t/documentation-guidelines/1245">Help improve the documentation</a></li>
           </ul>
         </div>
       </div>

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -82,7 +82,7 @@
           <h3>Still no luck?</h3>
           <ul class="p-list">
             <li class="p-list__item is-ticked"><a href="/docs">Visit jaas.io/docs</a></li>
-            <li class="p-list__item is-ticked"><a href="https://discourse.jujucharms.com">Ask on the forum</a></li>
+            <li class="p-list__item is-ticked"><a href="https://discourse.juju.is">Ask on the forum</a></li>
           </ul>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -412,7 +412,7 @@
             <a href="https://github.com/juju/juju" class="p-link--external">Juju on GitHub</a>
           </li>
           <li class="p-list__item">
-            <a href="https://discourse.jujucharms.com/" class="p-link--external">Juju on Discourse</a>
+            <a href="https://discourse.juju.is/">Juju on Discourse</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done
Updated the discourse links across the site and removed the external links.

## QA
- View the demo
- See the navigation link to discourse does not have an external link any more
- Check the link is now discourse.juju.is
