### PR TITLE
Update docs search to match Vanilla

### DIFF
--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -6,10 +6,10 @@
 {% block content %}
   <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
     <div class="row">
-      <form class="p-search-box u-no-margin--bottom" style="box-shadow: none" action="/docs/search">
+      <form class="p-search-box u-no-margin--bottom" action="/docs/search">
         <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
-        <button type="reset" class="p-search-box__reset u-no-margin" alt="reset" style="right: 6.7rem"><i class="p-icon--close"></i></button>
-        <button type="submit" class="p-button--positive u-no-margin--bottom" style="margin-left: 1.5rem; width: auto" alt="search">Search</button>
+        <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close">Reset</i></button>
+        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
       </form>
     </div>
   </section>


### PR DESCRIPTION
## Done
Updated the mark up to match the [Vanilla search pattern](https://vanillaframework.io/docs/patterns/search-box#main-content) and removed some bespoke styling.

## QA
- Open the demo
- Go to /docs
- Shrink the screen and see the search matches the screenshot and not like the image in the linked issue

## Screenshot
![Screenshot_2020-05-21 Juju documentation](https://user-images.githubusercontent.com/1413534/82600138-50755f80-9ba5-11ea-9157-48ebe41b7c18.png)

Fixes https://github.com/canonical-web-and-design/juju.is/issues/65