### PR TITLE
Add tracking to the carousel

### DIFF
--- a/static/js/tabpanel.js
+++ b/static/js/tabpanel.js
@@ -69,5 +69,18 @@ function triggerNextTab(tab) {
   if (!nextTab) {
     nextTab = document.querySelectorAll('.p-hero-tab__item')[0];
   }
+  recordEvent('carousel', 'autoplay', nextTab.id);
   changeTabs(nextTab);
+}
+
+function recordEvent(category, action, label) {
+  if (dataLayer) {
+    dataLayer.push({
+      event: 'GAEvent',
+      eventCategory: category,
+      eventAction: action,
+      eventLabel: label,
+      eventValue: undefined,
+    });
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -110,19 +110,43 @@
 
     <div class="row p-hero-tab">
       <div role="tablist" aria-label="Discover Juju services and solutons" class="p-hero-tab__list">
-        <button role="tab" aria-selected="true" aria-controls="panel-juju-as-a-service" id="juju-as-a-service" class="p-hero-tab__item">
+        <button role="tab" aria-selected="true" aria-controls="panel-juju-as-a-service" id="juju-as-a-service" class="p-hero-tab__item"
+          onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'carousel',
+            'eventAction' : 'click',
+            'eventLabel' : 'juju-as-a-service'
+          });">
           <i class="before"></i>
           <p class="p-hero-tab__title">Juju is DevOps automation</p>
         </button>
-        <button role="tab" aria-selected="false" aria-controls="panel-juju-expert-partners" id="juju-expert-partners" class="p-hero-tab__item">
+        <button role="tab" aria-selected="false" aria-controls="panel-juju-expert-partners" id="juju-expert-partners" class="p-hero-tab__item"
+          onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'carousel',
+            'eventAction' : 'click',
+            'eventLabel' : 'juju-expert-partners'
+          });">
           <i class="before"></i>
           <p class="p-hero-tab__title">Juju is multi-cloud SaaS</p>
         </button>
-        <button role="tab" aria-selected="false" aria-controls="panel-openstack-solutions" id="openstack-solutions" class="p-hero-tab__item">
+        <button role="tab" aria-selected="false" aria-controls="panel-openstack-solutions" id="openstack-solutions" class="p-hero-tab__item"
+          onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'carousel',
+            'eventAction' : 'click',
+            'eventLabel' : 'openstack-solutions'
+          });">
           <i class="before"></i>
           <p class="p-hero-tab__title">Juju is autonomous software</p>
         </button>
-        <button role="tab" aria-selected="false" aria-controls="panel-big-data-solutions" id="big-data-solutions" class="p-hero-tab__item">
+        <button role="tab" aria-selected="false" aria-controls="panel-big-data-solutions" id="big-data-solutions" class="p-hero-tab__item"
+          onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'carousel',
+            'eventAction' : 'click',
+            'eventLabel' : 'big-data-solutions'
+          });">
           <i class="before"></i>
           <p class="p-hero-tab__title">Juju is an alternative to OpenShift</p>
         </button>


### PR DESCRIPTION
## Done
Added tracking to the homepage carousel in the form of autoplay trigger and user click trigger.

## QA
- Go to the demo
- Waiting for the autoplay to switch to another panel and see if there is a GA event triggered
- Click on the next panel and see there is a GA event triggered
- Check there are no console errors

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1184