### PR TITLE
Redirect cloud-init.io to juju.is

### DIFF
--- a/deploy/site.yaml
+++ b/deploy/site.yaml
@@ -2,6 +2,9 @@ domain: juju.is
 
 image: prod-comms.docker-registry.canonical.com/juju.is
 
+extraHosts:
+  - domain: cloud-init.io
+
 env:
   - name: SENTRY_DSN
     value: https://a9c1a18b2a0a40bdae6177bb29331a2a@sentry.is.canonical.com//20


### PR DESCRIPTION
Moving https://github.com/canonical-web-and-design/deployment-configs/pull/390 here.

QA
--

I don't know how exactly we QA stuff in this new formulation, but these were the QA steps from the other PR:

``` bash
python3 -m venv .venv
source .venv/bin/activate
pip3 install -r requirements.txt
./qa-deploy production sites/juju.is.yaml latest
watch microk8s.kubectl get all,ingress
```

Once everything is "running" and the ingress has an IP assigned, do:

``` bash
$ curl -I --insecure -H 'Host: cloud-init.io' https://localhost
HTTP/2 301
location: https://juju.is/
```

And:

``` bash
$ curl -I --insecure -H 'Host: juju.is' https://localhost
HTTP/2 200
```