### PR TITLE
Fix carousel jump when changing tabs

### DIFF
--- a/static/sass/_patterns_hero-tab.scss
+++ b/static/sass/_patterns_hero-tab.scss
@@ -44,6 +44,18 @@
         outline: 0;
       }
 
+      &[aria-selected="false"] {
+        .before {
+          background-color: transparent;
+          content: "";
+          display: block;
+          height: 2px;
+          position: relative;
+          top: -1px;
+          width: 100%;
+        }
+      }
+
       &[aria-selected='true'] {
         * {
           opacity: 1;

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
             url="https://assets.ubuntu.com/v1/26415d45-slide-simple.svg",
             alt="",
             width="300",
-            height="374",
+            height="215",
             hi_def=True,
             loading="eager",
             ) | safe
@@ -56,7 +56,7 @@
             url="https://assets.ubuntu.com/v1/f2e4e9fb-slide-opensource.svg",
             alt="",
             width="300",
-            height="374",
+            height="254",
             hi_def=True,
             ) | safe
           }}
@@ -82,7 +82,7 @@
             url="https://assets.ubuntu.com/v1/3c6d2c1e-slide-automation.svg",
             alt="",
             width="300",
-            height="374",
+            height="300",
             hi_def=True,
             ) | safe
           }}
@@ -108,7 +108,7 @@
             url="https://assets.ubuntu.com/v1/06d371ed-slide-appmodeling.svg",
             alt="",
             width="300",
-            height="374",
+            height="218",
             hi_def=True,
             ) | safe
           }}


### PR DESCRIPTION
## Done
- Fix height jump when switching between tabs
- Align all the horizontal lines in the tabs with the selected one

## QA
Go to http://0.0.0.0:8041/ and click on the carousel tabs. See there is no jump when switching between tabs.


## Issue
Fixes #86 