### PR TITLE
Rename /about to /overview and make /mission the index

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -138,11 +138,11 @@
           </span>
           <ul class="p-navigation__links" role="menu">
             <li
-              class="p-navigation__link{% if request.path.startswith('/about') %} is-selected"
+              class="p-navigation__link{% if request.path.startswith('/overview') %} is-selected"
               aria-current="page{% endif %}"
               role="menuitem"
             >
-              <a href="/about">About</a>
+              <a href="/mission">Overview</a>
             </li>
             <li
               class="p-navigation__link{% if request.path.startswith('/tutorials') %} is-selected"

--- a/templates/overview/architecture.html
+++ b/templates/overview/architecture.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Architecture of the Juju OLM{% endblock title %}
 

--- a/templates/overview/base.html
+++ b/templates/overview/base.html
@@ -23,7 +23,7 @@
               <a class="p-side-navigation__link{% if request.path == '/mission' %} is-active{% endif %}" href="/mission">Mission</a>
             </li>
             <li class="p-side-navigation__item">
-              <a class="p-side-navigation__link{% if request.path == '/about' %} is-active{% endif %}" href="/about">OLM Overview</a>
+              <a class="p-side-navigation__link{% if request.path == '/overview' %} is-active{% endif %}" href="/overview">OLM Overview</a>
             </li>
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link{% if request.path == '/model-driven-operations' %} is-active{% endif %}" href="/model-driven-operations">Model-driven ops</a>

--- a/templates/overview/beyond-configuration-management.html
+++ b/templates/overview/beyond-configuration-management.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Juju makes configuration management obsolete{% endblock title %}
 

--- a/templates/overview/devsecops.html
+++ b/templates/overview/devsecops.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}The operator pattern and devsecops{% endblock title %}
 

--- a/templates/overview/high-availability-enterprise-olm.html
+++ b/templates/overview/high-availability-enterprise-olm.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Highly available OLM service for enterprise applications{% endblock title %}
 

--- a/templates/overview/hosted-olm.html
+++ b/templates/overview/hosted-olm.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Hosted operator lifecycle manager - SAAS OLM{% endblock title %}
 

--- a/templates/overview/index.html
+++ b/templates/overview/index.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Overview of the Juju Operator Lifecycle Manager{% endblock title %}
 

--- a/templates/overview/integration.html
+++ b/templates/overview/integration.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Reusable integration code with the operator pattern and Juju OLM{% endblock title %}
 

--- a/templates/overview/mission.html
+++ b/templates/overview/mission.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}The Juju mission statement{% endblock title %}
 

--- a/templates/overview/model-driven-operations.html
+++ b/templates/overview/model-driven-operations.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Model-driven operators capture business decisions{% endblock title %}
 

--- a/templates/overview/multi-cloud-operations.html
+++ b/templates/overview/multi-cloud-operations.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Multi-cloud operations{% endblock title %}
 

--- a/templates/overview/operator-lifecycle-manager.html
+++ b/templates/overview/operator-lifecycle-manager.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Juju is an enterprise Operator Lifecycle Manager{% endblock title %}
 

--- a/templates/overview/operator-services.html
+++ b/templates/overview/operator-services.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Operator services{% endblock title %}
 

--- a/templates/overview/ops-code-quality.html
+++ b/templates/overview/ops-code-quality.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 {% block title %}Factors in ops code quality{% endblock title %}
 {% block meta_copydoc %}https://docs.google.com/document/d/18_PRa2HA_P1j5JCbhZ0PsTRl9oVUHoeh6dI9u8GqQIs/edit{% endblock meta_copydoc %}
 {% block meta_description %}Let’s elevate operations code to industrial scale and quality. Take infrastructure as code, and add open source principles to create a shared body of operations code that works every time, every place, on every architecture, under every load.{% endblock %}

--- a/templates/overview/universal-operators.html
+++ b/templates/overview/universal-operators.html
@@ -1,4 +1,4 @@
-{% extends 'about/base.html' %}
+{% extends 'overview/base.html' %}
 
 {% block title %}Operators for infrastructure, traditional, and legacy applications{% endblock title %}
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -22,67 +22,67 @@ app = FlaskBase(
 
 @app.route("/integration")
 def integration():
-    return render_template("about/integration.html")
+    return render_template("overview/integration.html")
 
 
 @app.route("/model-driven-operations")
 def model_driven_operations():
-    return render_template("about/model-driven-operations.html")
+    return render_template("overview/model-driven-operations.html")
 
 
 @app.route("/devsecops")
 def devsecops():
-    return render_template("about/devsecops.html")
+    return render_template("overview/devsecops.html")
 
 
 @app.route("/universal-operators")
 def universal_operators():
-    return render_template("about/universal-operators.html")
+    return render_template("overview/universal-operators.html")
 
 
 @app.route("/operator-services")
 def operator_services():
-    return render_template("about/operator-services.html")
+    return render_template("overview/operator-services.html")
 
 
 @app.route("/mission")
 def mission():
-    return render_template("about/mission.html")
+    return render_template("overview/mission.html")
 
 
 @app.route("/high-availability-enterprise-olm")
 def high_availability_enterprise_olm():
-    return render_template("about/high-availability-enterprise-olm.html")
+    return render_template("overview/high-availability-enterprise-olm.html")
 
 
 @app.route("/architecture")
 def architecture():
-    return render_template("about/architecture.html")
+    return render_template("overview/architecture.html")
 
 
 @app.route("/operator-lifecycle-manager")
 def operator_lifecycle_manager():
-    return render_template("about/operator-lifecycle-manager.html")
+    return render_template("overview/operator-lifecycle-manager.html")
 
 
 @app.route("/ops-code-quality")
 def ops_code_quality():
-    return render_template("about/ops-code-quality.html")
+    return render_template("overview/ops-code-quality.html")
 
 
 @app.route("/hosted-olm")
 def hosted_olm():
-    return render_template("about/hosted-olm.html")
+    return render_template("overview/hosted-olm.html")
 
 
 @app.route("/multi-cloud-operations")
 def multi_cloud_operations():
-    return render_template("about/multi-cloud-operations.html")
+    return render_template("overview/multi-cloud-operations.html")
 
 
 @app.route("/beyond-configuration-management")
 def beyond_configuration_management():
-    return render_template("about/beyond-configuration-management.html")
+    return render_template("overview/beyond-configuration-management.html")
 
 
 template_finder_view = TemplateFinder.as_view("template_finder")


### PR DESCRIPTION
## Done

- rename /about to /mission in the menu and filesystem
- make /mission the page the menu goes to
- I did not redirect /about as there is no redirects.yaml - personally I don't think it is required as the site hasn't been indexed yet.

## QA

1. download this branch and dotrun it
2. go to http://0.0.0.0:8041/
3. see that the About menu item is now named Overview
4. click on Overview and see that it goes to /mission
5. click in sidebar and see that links work

Fixes #1638