### PR TITLE
Fix get-in-touch buttons spacing on mobile

### DIFF
--- a/static/sass/_patterns_p-modal.scss
+++ b/static/sass/_patterns_p-modal.scss
@@ -5,4 +5,16 @@
       min-width: 875px;
     }
   }
+
+  .pagination__link--previous {
+    margin-inline-end: 1rem;
+
+    @media screen and (min-width: $breakpoint-medium) {
+      margin-block-end: 0;
+    }
+  }
+
+  .pagination__link--next {
+    margin-block-end: 0;
+  }
 }

--- a/templates/partials/_get-in-touch.html
+++ b/templates/partials/_get-in-touch.html
@@ -61,7 +61,7 @@
         <textarea id="describe-your-project" name="describe-your-project" aria-label="Describe your project" rows="3"></textarea>
       </div>
       <div class="pagination">
-        <a class="p-button--positive pagination__link--next u-no-margin--bottom" href="">Next</a>
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
       </div>
     </div>
 
@@ -177,17 +177,17 @@
         </div>
       </div>
       <div class="pagination">
-        <a class="pagination__link--previous p-button--neutral u-no-margin--bottom" href="">Previous</a>
-        <a class="pagination__link--next p-button--positive u-no-margin--bottom" href="">Next</a>
+        <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+        <a class="pagination__link--next p-button--positive" href="">Next</a>
       </div>
     </div>
 
     <div class="js-pagination js-pagination--3 u-hide">
       <h3 class="p-heading--five">How should we get in touch?</h3>
-      <div class="row u-no-padding">
-        <div class="col-6">
-          <form class="modal-form marketo-form" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1337">
-            <ul class="p-list">
+      <form class="modal-form marketo-form" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1337">
+        <div class="row u-no-padding">
+          <div class="col-6">
+            <ul class="p-list u-no-margin--bottom">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
                 <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
@@ -199,16 +199,6 @@
               <li class="mktFormReq mktField p-list__item">
                 <label for="Email" class="mktoLabel">Email address:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
-              </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">Please send me information about Canonical’s products and services.</label>
-              </li>
-              <li class="p-list__item">
-                <p>Submitting this form confirms that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact" class="p-link--external">Canonical&rsquo;s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" class="p-link--external">Privacy Policy</a>.</p>
-              </li>
-              <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 
@@ -234,14 +224,27 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="http://juju.is/thank-you" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
             </div>
-
-            <div class="pagination">
-              <a class="pagination__link--previous p-button--neutral u-no-margin--bottom" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton u-no-margin--bottom" aria-label="Submit">Let's discuss</button>
-            </div>
-          </form>
+          </div>
         </div>
-      </div>
+        <div class="u-fixed-width u-no-padding">
+          <ul class="p-list">
+            <li class="mktField p-list__item">
+              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">Please send me information about Canonical’s products and services.</label>
+            </li>
+            <li class="p-list__item">
+              <p>Submitting this form confirms that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact" class="p-link--external">Canonical&rsquo;s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy" class="p-link--external">Privacy Policy</a>.</p>
+            </li>
+            <li class="p-list__item">
+              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+            </li>
+          </ul>
+          <div class="pagination">
+            <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+            <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+          </div>
+        </div>
+      </form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Fix `get-in-touch` form buttons spacing on mobile
- Make the text on the last page of the `get-in-touch` form wider

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041#get-in-touch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is space between the buttons on mobile. See the text on the last page is wider


## Issue / Card

Fixes #

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/94824848-59045f00-03fd-11eb-8121-75e441762367.png)

![image](https://user-images.githubusercontent.com/40214246/94824897-67527b00-03fd-11eb-8a87-43e92748faf8.png)

