### PR TITLE
Integrate cookie-policy v3.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ dist/
 .dotrun.json
 .venv/
 .webcache/
+static/js/modules/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
-    "build-js": "mkdir -p static/js/build/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/build/global-nav",
+    "build-js": "yarn run copy-cookie-policy && yarn run copy-global-nav",
+    "copy-cookie-policy": "mkdir -p static/js/modules/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy",
+    "copy-global-nav": "mkdir -p static/js/build/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/build/global-nav",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "sass-lint static/**/*.scss --verbose --no-exit",
@@ -16,6 +18,7 @@
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python"
   },
   "dependencies": {
+    "@canonical/cookie-policy": "3.0.4",
     "@canonical/global-nav": "2.4.3",
     "autoprefixer": "9.8.6",
     "concurrently": "5.3.0",

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -6,6 +6,9 @@ $color-accent: #f0f5f7;
 @import "vanilla-framework/scss/vanilla";
 @include vanilla;
 
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
+
 @import "patterns_docs";
 @import "hljs";
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -189,6 +189,9 @@
               <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>
             </li>
             <li class="p-inline-list__item">
+              <a class="p-footer__link js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+            </li>
+            <li class="p-inline-list__item">
               <a class="p-link--inverted" href="https://github.com/canonical-web-and-design/juju.is/issues/new">Report a bug on
                 this site</a>
             </li>
@@ -233,7 +236,9 @@
     <script src="{{ versioned_static('js/dynamic-contact-form.js') }}"></script>
 
     <script src="/static/js/build/global-nav/global-nav.js"></script>
+    <script src="/static/js/modules/cookie-policy/cookie-policy.js"></script>
     <script>
+      cpNs.cookiePolicy();
       canonicalGlobalNav.createNav({ maxWidth: "72rem", showLogins: false });
     </script>
   </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@canonical/cookie-policy@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
+  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
Integrate cookie-policy v3.0.4

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Check the cookie policy appears
- Check the manager opens and works
- Make a selection and the notification should disappear
- Scroll to the footer and click the Manage link in the footer
- See that manager appears again. 

## Issue / Card
