### PR TITLE
Update GTM and add cookie policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "scripts": {
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
+    "clean": "rm -rf node_modules yarn-error.log css static/css static/js/build *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
-    "build-js": "mkdir -p static/js/build/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/build/global-nav",
+    "build-js": "yarn run build-global-nav && yarn run build-cookie-policy",
+    "build-global-nav": "mkdir -p mkdir -p static/js/build/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/build/global-nav",
+    "build-cookie-policy": "mkdir -p static/js/build/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/build/cookie-policy",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "sass-lint static/**/*.scss --verbose --no-exit",
@@ -16,6 +18,7 @@
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python"
   },
   "dependencies": {
+    "@canonical/cookie-policy": "3.0.4",
     "@canonical/global-nav": "2.4.3",
     "autoprefixer": "10.0.1",
     "concurrently": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
     "build-js": "yarn run build-global-nav && yarn run build-cookie-policy",
-    "build-global-nav": "mkdir -p mkdir -p static/js/build/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/build/global-nav",
+    "build-global-nav": "mkdir -p static/js/build/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/build/global-nav",
     "build-cookie-policy": "mkdir -p static/js/build/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/build/cookie-policy",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -6,6 +6,9 @@ $color-accent: #f0f5f7;
 @import "vanilla-framework/scss/vanilla";
 @include vanilla;
 
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
+
 @import "patterns_docs";
 @import "hljs";
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,49 +35,6 @@
     ></script>
     <script src="https://buttons.github.io/buttons.js" defer></script>
 
-    <!-- Google Analytics and Google Optimize -->
-    <script>
-      (function(i, s, o, g, r, a, m) {
-        i["GoogleAnalyticsObject"] = r;
-        (i[r] =
-          i[r] ||
-          function() {
-            (i[r].q = i[r].q || []).push(arguments);
-          }),
-          (i[r].l = 1 * new Date());
-        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m);
-      })(
-        window,
-        document,
-        "script",
-        "https://www.google-analytics.com/analytics.js",
-        "ga"
-      );
-      ga("create", "UA-1018242-59", "auto", { allowLinker: true });
-      ga("require", "GTM-WVQJJBD");
-      ga("require", "linker");
-      ga("linker:autoLink", [
-        "conjure-up.io",
-        "login.ubuntu.com",
-        "www.ubuntu.com",
-        "ubuntu.com",
-        "insights.ubuntu.com",
-        "developer.ubuntu.com",
-        "cn.ubuntu.com",
-        "design.ubuntu.com",
-        "maas.io",
-        "canonical.com",
-        "landscape.canonical.com",
-        "pages.ubuntu.com",
-        "tutorials.ubuntu.com",
-        "docs.ubuntu.com"
-      ]);
-    </script>
-    <!-- End Google Analytics and Google Optimize -->
-
     <!-- Google Tag Manager -->
     <script>
       (function(w, d, s, l, i) {
@@ -92,7 +49,7 @@
         j.async = true;
         j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-T5SMPTS");
+      })(window, document, "script", "dataLayer", "GTM-K9KCMZ");
     </script>
     <!-- End Google Tag Manager -->
   </head>
@@ -101,7 +58,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript
       ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-T5SMPTS"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-K9KCMZ"
         height="0"
         width="0"
         style="display:none;visibility:hidden"
@@ -189,6 +146,9 @@
               <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>
             </li>
             <li class="p-inline-list__item">
+              <a class="p-link--inverted js-revoke-cookie-manager"  href="">Manage your tracker settings</a>
+            </li>
+            <li class="p-inline-list__item">
               <a class="p-link--inverted" href="https://github.com/canonical-web-and-design/juju.is/issues/new">Report a bug on
                 this site</a>
             </li>
@@ -233,8 +193,10 @@
     <script src="{{ versioned_static('js/dynamic-contact-form.js') }}"></script>
 
     <script src="/static/js/build/global-nav/global-nav.js"></script>
+    <script src="/static/js/build/cookie-policy/cookie-policy.js"></script>
     <script>
       canonicalGlobalNav.createNav({ maxWidth: "72rem", showLogins: false });
+      cpNs.cookiePolicy();
     </script>
   </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@canonical/cookie-policy@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
+  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done

- Update GTM and add cookie policy
- Removed the optimise code as it isn't being used

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the cookie popup works, it in the footer and the GTM code is `GTM-K9KCMZ`

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3269
