### PR TITLE
Add Operator Framework CTA to footer

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -121,3 +121,19 @@ $color-accent: #f0f5f7;
 h3 {
   font-weight: 200;
 }
+
+.p-button--outline {
+  @extend %vf-button-base;
+
+  border-color: $color-x-light;
+  color: $color-x-light;
+
+  &:visited {
+    color: $color-x-light;
+  }
+
+  &:hover,
+  &:active:hover {
+    background-color: rgba($color-mid-x-light, 0.2);
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -135,59 +135,7 @@
 
     {% block content %}{% endblock %}
 
-    <footer class="p-strip--suru-top has-accent is-dark {% if request.path == '/' %}is-homepage{% endif %}"
-      style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
-      <div class="row">
-        <div class="col-8">
-          <p class="u-no-max-width">&copy; {{ current_year }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
-          </p>
-          <ul class="p-inline-list--middot">
-            <li class="p-inline-list__item">
-              <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--inverted js-revoke-cookie-manager"  href="">Manage your tracker settings</a>
-            </li>
-            <li class="p-inline-list__item">
-              <a class="p-link--inverted" href="https://github.com/canonical-web-and-design/juju.is/issues/new">Report a bug on
-                this site</a>
-            </li>
-          </ul>
-          <nav>
-            <ul class="p-inline-list--middot">
-              <li class="p-inline-list__item">
-                <a class="p-link--inverted" href="/docs">Docs</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a class="p-link--inverted" href="/tutorials">Tutorials</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a class="p-link--inverted" href="https://discourse.juju.is/">Discourse</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a class="p-link--inverted" href="/docs/installing">Install Juju</a>
-              </li>
-            </ul>
-            <span class="u-off-screen">
-              <a href="#">Go to the top of the page</a>
-            </span>
-          </nav>
-        </div>
-        <div class="col-4 u-align--right">
-          <ul class="p-inline-list">
-            <li class="p-inline-list__item">
-              <a href="http://www.facebook.com/ubuntucloud" class="p-icon--facebook"></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="http://www.twitter.com/juju_devops" class="p-icon--twitter"></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="http://youtube.com/jujucharms" class="p-icon--youtube"></a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </footer>
+    {% include "footer.html" %}
 
     <div class="u-hide" id="contact-form-container" data-form-location="/get-in-touch" data-form-id="1337" data-lp-id="2313" data-return-url="http://juju.is/thank-you" data-lp-url=""></div>
     <script src="{{ versioned_static('js/dynamic-contact-form.js') }}"></script>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,0 +1,61 @@
+<footer class="p-strip--suru-top has-accent is-dark {% if request.path == '/' %}is-homepage{% endif %}"
+  style="background-size: auto 100%, cover; background-image: url('https://assets.ubuntu.com/v1/8951dc67-suru-left.svg'), linear-gradient(266deg, #044f66, #022935)">
+  <div class="row">
+    <div class="col-8">
+      <h3>The Operator Framework</h3>
+      <p>The Operator Framework provides a simple, lightweight, and powerful way of writing Juju charms, the best way to encapsulate operational experience in code.</p>
+      <ul class="p-inline-list u-sv3">
+        <li class="p-inline-list__item"><a href="https://github.com/canonical/operator/" class="p-button--neutral">Get involved</a>
+        </li>
+      </ul>
+      <p class="u-no-max-width">&copy; {{ current_year }} Canonical Ltd. Ubuntu and Canonical are registered trademarks
+        of Canonical Ltd.
+      </p>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item">
+          <a class="p-link--inverted p-link--external" href="https://www.ubuntu.com/legal">Legal Information</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--inverted js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a class="p-link--inverted" href="https://github.com/canonical-web-and-design/juju.is/issues/new">Report a bug
+            on
+            this site</a>
+        </li>
+      </ul>
+      <nav>
+        <ul class="p-inline-list--middot">
+          <li class="p-inline-list__item">
+            <a class="p-link--inverted" href="/docs">Docs</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--inverted" href="/tutorials">Tutorials</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--inverted" href="https://discourse.juju.is/">Discourse</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--inverted" href="/docs/installing">Install Juju</a>
+          </li>
+        </ul>
+        <span class="u-off-screen">
+          <a href="#">Go to the top of the page</a>
+        </span>
+      </nav>
+    </div>
+    <div class="col-4 u-align--right">
+      <ul class="p-inline-list">
+        <li class="p-inline-list__item">
+          <a href="http://www.facebook.com/ubuntucloud" class="p-icon--facebook"></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="http://www.twitter.com/juju_devops" class="p-icon--twitter"></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="http://youtube.com/jujucharms" class="p-icon--youtube"></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</footer>


### PR DESCRIPTION
Fixes #147

## Done

Add Operator Framework CTA to footer

Note: I added contact link as https://charmhub.io/#get-in-touch - is this correct?

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Scroll to footer and see new CTA to Operator Framework


## Issue / Card

Fixes #147
