### PR TITLE
Fix docs title

### DIFF
--- a/templates/docs/base.html
+++ b/templates/docs/base.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block page_class %}docs{% endblock %}
-{% block page_title %}Juju {% if document %}| {{ document.title }}{% endif %}{% endblock %}
+{% block page_title %}{% if document %}{{ document.title }}{% else %}Docs{% endif %}{% endblock %}
 
 {% block content %}
   <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">


### PR DESCRIPTION
## Done

- fix duplicate juju in docs title

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- make sure docs title have `Juju | NAME OF DOCS`


## Issue / Card

Fixes #159 
