### PR TITLE
Revert the community page content to the original content

### DIFF
--- a/templates/community.html
+++ b/templates/community.html
@@ -15,12 +15,12 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title u-no-margin--bottom">Discussions</h3>
-      <p class="p-card__title"><a href="https://discourse.charmhub.io/">discourse.charmhub.io</a></p>
+      <p class="p-card__title"><a href="https://discourse.charmhub.io/" class="p-link--external">discourse.charmhub.io</a></p>
       <p class="p-card__content">About Juju and charm development</p>
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title u-no-margin--bottom">Code</h3>
-      <p class="p-card__title"><a href="https://github.com/juju/juju">github.com/juju/juju</a></p>
+      <p class="p-card__title"><a href="https://github.com/juju/juju" class="p-link--external">github.com/juju/juju</a></p>
       <p class="p-card__content">Contributions to the Juju OLM</p>
     </div>
   </div>
@@ -32,26 +32,26 @@
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title u-no-margin--bottom">Bugs</h3>
-      <p class="p-card__title"><a href="https://bugs.launchpad.net/juju">bugs.launchpad.net/juju</a></p>
+      <p class="p-card__title"><a href="https://bugs.launchpad.net/juju" class="p-link--external">bugs.launchpad.net/juju</a></p>
       <p class="p-card__content">Thank you :)</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title u-no-margin--bottom">Charms</h3>
-      <p class="p-card__title"><a href="https://charmhub.io">charmhub.io</a></p>
+      <p class="p-card__title"><a href="https://charmhub.io" class="p-link--external">charmhub.io</a></p>
       <p class="p-card__content">Home of the Open Operator Collection</p>
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title u-no-margin--bottom">Operator Framework</h3>
-      <p class="p-card__title"><a href="https://pythonoperatorframework.io">pythonoperatorframework.io</a></p>
+      <p class="p-card__title"><a href="https://pythonoperatorframework.io" class="p-link--external">pythonoperatorframework.io</a></p>
       <p class="p-card__content">Pure Python operator development</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title u-no-margin--bottom">SAAS</h3>
-      <p class="p-card__title"><a href="https://jaas.ai">jaas.ai</a></p>
+      <p class="p-card__title"><a href="https://jaas.ai" class="p-link--external">jaas.ai</a></p>
       <p class="p-card__content">Fully managed multi cloud Juju services</p>
     </div>
   </div>

--- a/templates/community.html
+++ b/templates/community.html
@@ -5,10 +5,55 @@
 {% block page_description %}We welcome you to participate in all areas of the Juju community.  Explore the many resources, forums, code, services and support on offer.{% endblock %}
 
 {% block content %}
-<section class="p-strip--suru-topped">
+<section class="p-strip--suru-topped u-no-padding--bottom">
   <div class="row">
     <h1>Community</h1>
-    <p>We welcome you to participate in all areas of the Juju community.  Explore the many resources, forums, code, services and support on offer.</p>
+  </div>
+</section>
+
+<section class="p-strip is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title u-no-margin--bottom">Discussions</h3>
+      <p class="p-card__title"><a href="https://discourse.charmhub.io/">discourse.charmhub.io</a></p>
+      <p class="p-card__content">About Juju and charm development</p>
+    </div>
+    <div class="col-6 p-card">
+      <h3 class="p-card__title u-no-margin--bottom">Code</h3>
+      <p class="p-card__title"><a href="https://github.com/juju/juju">github.com/juju/juju</a></p>
+      <p class="p-card__content">Contributions to the Juju OLM</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title u-no-margin--bottom">Support</h3>
+      <p class="p-card__title"><a href="/contact-us">juju.is/contact-us</a></p>
+      <p class="p-card__content">Canonical enterprise support and services</p>
+    </div>
+    <div class="col-6 p-card">
+      <h3 class="p-card__title u-no-margin--bottom">Bugs</h3>
+      <p class="p-card__title"><a href="https://bugs.launchpad.net/juju">bugs.launchpad.net/juju</a></p>
+      <p class="p-card__content">Thank you :)</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title u-no-margin--bottom">Charms</h3>
+      <p class="p-card__title"><a href="https://charmhub.io">charmhub.io</a></p>
+      <p class="p-card__content">Home of the Open Operator Collection</p>
+    </div>
+    <div class="col-6 p-card">
+      <h3 class="p-card__title u-no-margin--bottom">Operator Framework</h3>
+      <p class="p-card__title"><a href="https://pythonoperatorframework.io">pythonoperatorframework.io</a></p>
+      <p class="p-card__content">Pure Python operator development</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title u-no-margin--bottom">SAAS</h3>
+      <p class="p-card__title"><a href="https://jaas.ai">jaas.ai</a></p>
+      <p class="p-card__content">Fully managed multi cloud Juju services</p>
+    </div>
   </div>
 </section>
 <div class="u-fixed-width">
@@ -16,63 +61,13 @@
 </div>
 <section class="p-strip">
   <div class="row">
-    <div class="col-5">
-      <h2>Get involved</h2>
-    </div>
-    <div class="col-6 col-start-large-7">
-      <h3 class="p-heading--5 u-no-margin--bottom"><a href="https://discourse.charmhub.io" class="p-link--external">Discussions</a></h3>
-      <p>Join the teams building Juju and charm development. Ask questions, learn, share and help shape the direction of the framework.</p>
-      <h3 class="p-heading--5 u-no-margin--bottom"><a href="https://github.com/juju/juju" class="p-link--external">Code</a></h3>
-      <p>Want to checkout the code or contribute to the Juju OLM? It is all open on GitHub. We always welcome PRs.</p>
-      <h3 class="p-heading--5 u-no-margin--bottom"><a href="https://bugs.launchpad.net/juju" class="p-link--external">Bugs</a></h3>
-      <p>If you have found a bug, please file and issue, it helps the whole community and framework get better. Thank you :)</p>
-    </div>
-  </div>
-</section>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-<section class="p-strip">
-  <div class="row">
-    <div class="col-5">
-      <h2>Get started</h2>
-    </div>
-    <div class="col-6 col-start-large-7">
-      <h3 class="p-heading--5 u-no-margin--bottom"><a href="https://charmhub.io/" class="p-link--external">Charms</a></h3>
-      <p>Home of the Open Operator Collection. Search and browse for Operators or add yours to the list.</p>
-      <h3 class="p-heading--5 u-no-margin--bottom"><a href="https://github.com/canonical/operator" class="p-link--external">Operator Framework</a></h3>
-      <p>Pure Python operator development. Build your own operators with the open operator framework&rsquo;s libraries.</p>
-    </div>
-  </div>
-</section>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-<section class="p-strip">
-  <div class="row">
-    <div class="col-5">
-      <h2>Get serious</h2>
-    </div>
-    <div class="col-6 col-start-large-7">
-      <h3 class="p-heading--5 u-no-margin--bottom"><a href="/contact-us">Support</a></h3>
-      <p>Using Juju in your enterprise, check out the  commercial support and services from Canonical.</p>
-      <h3 class="p-heading--5 u-no-margin--bottom"><a href="https://jaas.ai" class="p-link--external">SAAS</a></h3>
-      <p>Run your operators on Canonical’s fully managed multi cloud Juju services including; Microsoft Azure, Google Cloud and AWS.</p>
-    </div>
-  </div>
-</section>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-<section class="p-strip">
-  <div class="row">
-    <h2 class="u-sv3 u-off-screen">Sponsors</h2>
-    <div class="p-heading-icon--small">
+    <h2>Sponsors</h2>
+    <p class="p-heading-icon--small">
       <div class="p-heading-icon__header">
         <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/8dffa60d-canonical_aubergine_hex.svg" alt="">
-        <h4 class="p-heading-icon__title">Sponsored by <a href="https://canonical.com" class="p-link--external">Canonical</a></h4>
+        <h4 class="p-heading-icon__title"><a href="https://canonical.com" class="p-link--external">Canonical</a></h4>
       </div>
     </div>
-  </div>
+  </p>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Done
Revert the community page content to the original content

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041/community
- Check it matches the copy doc
