### PR TITLE
Fix install instructions for Linux

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -602,8 +602,8 @@
 							attrs={"style": "margin: 27px 0; height: 90px;"},
 						) | safe
 					}}
-					<pre class="p-code-numbered"><code><span class="p-code-numbered__line">sudo snap install juju</span></code></pre>
-					<p><a href="/docs/installing#heading--ubuntu">Install instructions&nbsp;&rsaquo;</a></p>
+					<pre class="p-code-numbered"><code><span class="p-code-numbered__line">sudo snap install --classic juju</span></code></pre>
+					<p><a href="/docs/installing#heading--linux">Install instructions&nbsp;&rsaquo;</a></p>
 				</div>
 				<div class="col-4">
 					{{


### PR DESCRIPTION
## Done

Fixed install instructions for Linux - needed `--classic` for the snap, and the anchor link was wrong for the detailed install instructions

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

## Screenshots