### PR TITLE
Use original Discourse topic for docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==0.7.3
 canonicalwebteam.yaml-responses==1.1.1
-canonicalwebteam.discourse==3.0.5
+canonicalwebteam.discourse==3.0.6
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -6,7 +6,7 @@ from canonicalwebteam.search import build_search_view
 
 
 def init_docs(app, url_prefix):
-    discourse_index_id = 3994
+    discourse_index_id = 1087
 
     session = talisker.requests.get_session()
     discourse_docs = Docs(


### PR DESCRIPTION
## Done

- We created a provisional topic in https://github.com/canonical-web-and-design/juju.is/pull/166 to avoid downtime errors in `/docs`
- Now we can use the [original docs topic](https://discourse.charmhub.io/t/juju-documentation-cover-page/1087), as it has been updated for v3.

## QA

- Check the documentation pages work as expected: https://juju-is-171.demos.haus/docs
