### PR TITLE
Update Discourse v3.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==0.7.3
 canonicalwebteam.yaml-responses==1.1.1
-canonicalwebteam.discourse==3.0.7
+canonicalwebteam.discourse==3.0.8
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
## Done

- This update fixed an issue with relative Discourse links

## QA

- Go to: http://0.0.0.0:8041/docs/kubernetes
- Check all the link at the end of the page work and take you to Discourse
