### PR TITLE
Add blog module to juju.is

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+canonicalwebteam.blog==6.3.1
 canonicalwebteam.flask-base==0.7.3
 canonicalwebteam.yaml-responses==1.1.1
 canonicalwebteam.discourse==3.0.8

--- a/templates/blog/_blog-card.html
+++ b/templates/blog/_blog-card.html
@@ -1,0 +1,24 @@
+<div class="col-4 col-medium-3 p-card">
+    {% if article.categories[0] in used_categories %}
+      <header class="p-card__header">
+        <h5 class="p-muted-heading u-no-margin--bottom">{{ used_categories[article.categories[0]].name }}</h5>
+      </header>
+    {% endif %}
+    <div class="p-card__content">
+      {% if article.image and article.image.source_url %}
+        <div class="u-crop--16-9">
+          <a href="/blog/{{ article.slug }}">
+            {{ article.image.rendered|safe }}
+          </a>
+        </div>
+      {% endif %}
+      <h3 class="p-heading--4">
+        <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
+      </h3>
+      <p><em>by {{ article.author.name }} on {{ article.date }}</em></p>
+      {% if not article.image %}
+        <p class="u-no-padding--bottom">{{ article.excerpt.raw }}</p>
+      {% endif %}
+    </div>
+  </div>
+  

--- a/templates/blog/_newsletter-signup.html
+++ b/templates/blog/_newsletter-signup.html
@@ -1,0 +1,38 @@
+<div class="p-card">
+    <h5 class="p-muted-heading">Newsletter Signup</h5>
+    <hr class="u-sv1" />
+      <div class="p-card__content js-newsletter-signup">
+          <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" class="p-form" id="mktoForm_3376">
+              <div class="p-form__group">
+                  <label for="Email" class="u-no-padding--top">Email:*</label>
+                  <input id="Email" name="Email" maxlength="255" type="email" required />
+              </div>
+              <div class="p-form__group">
+                  <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" type="checkbox" value="Receive updates"/>
+                  <label for="canonicalUpdatesOptIn">
+                      I agree to receive information about Canonical’s products and services.
+                  </label>
+              </div>
+              <p>
+                  <small>
+                      In submitting this form, I confirm that I have read and agree to
+                      <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank" id="">Canonical's Privacy Policy</a>
+                  </small>
+              </p>
+              <p class="u-no-margin--bottom">
+                  <input type="hidden" name="Consent_to_Processing__c" value="Yes" />
+                  <button type="submit" class="p-button--positive u-no-margin--bottom">Subscribe now</button>
+              </p>
+              <input type="hidden" name="formid" value="3376" />
+              <input type="hidden" name="lpId" value="" />
+              <input type="hidden" name="subId" value="" />
+              <input type="hidden" name="munchkinId" value="066-EOV-335" />
+              <input type="hidden" name="lpurl" value="" />
+              <input type="hidden" name="ret" value="juju.is{{path}}?newsletter=true" />
+              <input type="hidden" name="cr" value="" />
+              <input type="hidden" name="kw" value="" />
+              <input type="hidden" name="q" value="" />
+          </form>
+      </div>
+  </div>
+  

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,0 +1,125 @@
+{% extends 'base.html' %}
+
+{% block meta_title %}{{ article.title.rendered|safe }} | Snapcraft{% endblock %}
+{% block meta_description %}{{ article.excerpt.raw }}{% endblock %}
+{% block meta_copydoc %}{% endblock %}
+{% block meta_type %}article{% endblock %}
+{% if article.image and article.image.source_url %}
+  {% block meta_image %}{{ article.image.source_url }}{% endblock %}
+{% endif %}
+
+{% block meta_schema %}
+<script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@id": "https://juju.is/#article",
+      "@type": "Article",
+      "name": "{{ article.title.renderered|safe }}",
+      "author": {
+         "@type": "Person",
+         "name": "{{ article.author.name }}"
+      },
+      "datePublished": "{{ article.date_gmt }}",
+      {% if article.image and article.image.source_url %}
+        "image": "{{ article.image.source_url }}",
+      {% endif %}
+      "url": "https://juju.is{{ self.meta_path() }}",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Juju"
+      }
+    }
+  </script>
+{% endblock %}
+
+{% block extra_meta %}
+  <meta property="og:type" content="article" />
+  <meta property="article:published_time" content="{{ article.date_gmt }}" />
+  <meta property="article:author" content="{{ article.author.name }}" />
+{% endblock %}
+
+{% block content %}
+<section id="main-content" class="p-strip">
+  {% if newsletter_subscribed %}
+    <div class="row">
+      <div class="p-notification--positive">
+        <div class="p-notification__response"><b>Success:</b> Thanks for subscribing!</div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row">
+    <div class="col-8 p-blog-post">
+      <h1 class="p-heading--2">{{ article.title.rendered|safe }}</h1>
+      <p>by {{ article.author.name }} on {{ article.date }}</p>
+      {{ article.content.rendered|safe }}
+    </div>
+    <div class="col-4">
+      {% include 'blog/_newsletter-signup.html' %}
+    {% if is_in_series %}
+      {% for tag in tags %}
+        {% if tag.name.startswith('sc:series') %}
+          <div class="p-blog-aside">
+            <h4>In this series</h4>
+            <ul class="p-list p-blog-list" data-js="blog-series" data-series="{{ tag.id }}" data-currentslug="{{ article.slug }}">
+              <li class="p-list__item u-align--center">
+                <i class="p-icon--spinner u-animation--spin"></i>
+              </li>
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    </div>
+  </div>
+</section>
+
+{% if related_articles %}
+  <section class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      <h3>
+        Related posts
+      </h3>
+    </div>
+    <div class="row p-divider">
+      {% for related_article in related_articles %}
+        <div class="col-4 p-divider__block">
+          <h4>
+            <a href="/blog/{{ related_article.slug }}">
+              {{ related_article.title.rendered|safe }}
+            </a>
+          </h4>
+          <p>{{ related_article.excerpt.raw }}</p>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+{% endif %}
+
+<script type="text/template" id="blog-series-item-template">
+  <li class="p-list__item">
+    <h5>
+      <a href="/blog/${slug}" class="p-blog-list__item ${className}">
+        ${title}
+      </a>
+    </h5>
+  </li>
+</script>
+{% endblock %}
+
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/blog.js') }}" defer></script>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        {% if is_in_series %}
+        snapcraft.blog.seriesPosts('[data-js="blog-series"]', '#blog-series-item-template');
+        {% endif %}
+
+        snapcraft.public.blog.newsletter();
+      });
+    });
+  </script>
+{% endblock %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -1,0 +1,163 @@
+{% extends 'base.html' %}
+
+{% block meta_title %}Blog | Snapcraft{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1YWhw_DlbXrq9CBUtMgjzlzZds0_m8xr-MZlXpXkMvIQ/edit{% endblock %}
+{% block extra_meta %}
+<link rel="alternate" type="application/rss+xml"  href="/blog/feed" title="Juju.is's Blog RSS feed">
+{% endblock %}
+
+{% block content %}
+
+<section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
+  <div class="row">
+    <div class="col-10">
+      <h2 class="u-no-margin--bottom">Blog</h2>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow">
+  {% if newsletter_subscribed %}
+    <div class="row">
+      <div class="p-notification--positive">
+        <div class="p-notification__response"><b>Success:</b> Thanks for subscribing!</div>
+      </div>
+    </div>
+  {% endif %}
+  {% if categories %}
+    <div class="row u-align--right">
+      <form class="p-form p-form--inline" data-js="filterForm" method="get">
+        <div class="p-form__group">
+          <label class="p-form__label" for="filter" aria-label="Filter posts by category">Filter:</label>
+          <select id="filter" name="filter" class="p-form__control" name="filter">
+            <option value="all">All</option>
+            {% for category in categories %}
+              <option value="{{ category.name.lower() }}"{% if filter == category.name.lower() %} selected="selected"{% endif %}>
+                {{ category.name }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+      </form>
+    </div>
+  {% endif %}
+
+  <div class="row u-clearfix">
+    {% for article in articles %}
+      {% if current_page == 1 and loop.index == 3 %}
+        <div class="col-4 col-medium-3">
+          {% include 'blog/_newsletter-signup.html' %}
+        </div>
+      {% else %}
+        {% include 'blog/_blog-card.html' %}
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  <div class="u-fixed-width">
+    <ol class="p-pagination u-align--center">
+
+      {% if current_page > 1 %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link--previous" href="/blog?page={{ current_page - 1 }}" title="Previous page">
+            <i class="p-icon--contextual-menu">Previous page</i>
+          </a>
+        </li>
+      {% else %}
+        <li class="p-pagination__item">
+          <span class="p-pagination__link--previous is-disabled"><i class="p-icon--contextual-menu">Previous page</i></span>
+        </li>
+      {% endif %}
+
+      {# always show 5 pages in pagination #}
+      {% if current_page > 4 and current_page == total_pages %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 4 }}">{{ current_page - 4 }}</a>
+        </li>
+      {% endif %}
+
+      {% if current_page > 3 and current_page >= total_pages - 1 %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 3 }}">{{ current_page - 3 }}</a>
+        </li>
+      {% endif %}
+
+      {% if current_page > 2 %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 2 }}">{{ current_page - 2 }}</a>
+        </li>
+      {% endif %}
+
+      {% if current_page > 1 %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page - 1 }}">{{ current_page - 1 }}</a>
+        </li>
+      {% endif %}
+
+      <!-- current page -->
+      <li class="p-pagination__item">
+        <a class="p-pagination__link is-active" href="/blog?page={{ current_page }}">{{ current_page }}</a>
+      </li>
+
+      {% if current_page < total_pages %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 1 }}">{{ current_page + 1 }}</a>
+        </li>
+      {% endif %}
+
+      {% if current_page < total_pages - 1 %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 2 }}">{{ current_page + 2 }}</a>
+        </li>
+      {% endif %}
+
+      {% if current_page < total_pages - 2 and current_page <= 2 %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 3 }}">{{ current_page + 3 }}</a>
+        </li>
+      {% endif %}
+
+      {% if current_page < total_pages - 3 and current_page == 1 %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link" href="/blog?page={{ current_page + 4 }}">{{ current_page + 4 }}</a>
+        </li>
+      {% endif %}
+
+      {% if current_page != total_pages %}
+        <li class="p-pagination__item">
+          <a class="p-pagination__link--next" href="/blog?page={{ current_page + 1 }}" title="Next page">
+            <i class="p-icon--contextual-menu">Next page</i>
+          </a>
+        </li>
+      {% else %}
+        <li class="p-pagination__item">
+          <span class="p-pagination__link--next is-disabled"><i class="p-icon--contextual-menu">Next page</i></span>
+        </li>
+      {% endif %}
+    </ol>
+  </div>
+</section>
+
+{% endblock %}
+
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/blog.js') }}" defer></script>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    window.addEventListener("DOMContentLoaded", function() {
+      Raven.context(function () {
+        {% if categories %}
+          var filter = document.getElementById('filter');
+          var filterForm = document.querySelector('[data-js="filterForm"]');
+          filter.addEventListener('change', function(e) {
+            filterForm.submit();
+          });
+        {% endif %}
+
+        snapcraft.public.blog.newsletter();
+      });
+    });
+  </script>
+{% endblock %}

--- a/templates/sitemap/sitemap.xml
+++ b/templates/sitemap/sitemap.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>{{ base_url }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  {% for link in links %}
+  <url>
+    <loc>{{ link["url"] }}</loc>
+    {% if "last_udpated" in link %}
+    <lastmod>{{ link["last_udpated"] }}</lastmod>
+    {% endif %}
+    <changefreq>monthly</changefreq>
+  </url>
+  {% endfor %}
+</urlset>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -12,6 +12,7 @@ from flask import render_template
 from webapp.docs.views import init_docs
 from webapp.template_utils import current_url_with_query, static_url
 from webapp.tutorials.views import init_tutorials
+from webapp.blog.views import init_blog
 
 # Rename your project below
 app = FlaskBase(
@@ -109,6 +110,7 @@ app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 init_docs(app, "/docs")
 init_tutorials(app, "/tutorials")
+init_blog(app, "/blog")
 
 
 @app.context_processor

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -1,0 +1,87 @@
+import flask
+import talisker
+
+from canonicalwebteam.blog import (
+    BlogViews,
+    BlogAPI,
+    build_blueprint,
+)
+from dateutil import parser
+
+
+def init_blog(app, url_prefix):
+    session = talisker.requests.get_session()
+    blog_api = BlogAPI(
+        session=session,
+        thumbnail_width=354,
+        thumbnail_height=199,
+    )
+    blog = build_blueprint(
+        BlogViews(
+            api=blog_api,
+            blog_title="Juju Blog",
+            tag_ids=[4059],
+            excluded_tags=[3184, 3265, 3408],
+        )
+    )
+
+    @blog.context_processor
+    def add_newsletter():
+        newsletter_subscribed = flask.request.args.get(
+            "newsletter", default=False, type=bool
+        )
+
+        return {"newsletter_subscribed": newsletter_subscribed}
+
+    @blog.route("/sitemap.xml")
+    def sitemap():
+        base_url = "https://juju.is/blog"
+        links = []
+        page = 1
+        while True:
+            url = (
+                f"https://ubuntu.com/blog/wp-json/wp/v2/posts?"
+                f"tags=4059&per_page=100&page={page}"
+                f"&tags_exclude=3184%2C3265%2C3408"
+            )
+
+            response = session.get(url)
+            if response.status_code == 400:
+                break
+
+            try:
+                blog_response = response.json()
+            except Exception:
+                continue
+
+            for post in blog_response:
+                try:
+                    date = (
+                        parser.parse(post["date"])
+                        .replace(tzinfo=None)
+                        .strftime("%Y-%m-%d")
+                    )
+                    links.append(
+                        {
+                            "url": base_url + "/" + post["slug"],
+                            "last_udpated": date,
+                        }
+                    )
+                except Exception:
+                    continue
+
+            page = page + 1
+
+        xml_sitemap = flask.render_template(
+            "sitemap/sitemap.xml",
+            base_url=base_url,
+            links=links,
+        )
+
+        response = flask.make_response(xml_sitemap)
+        response.headers["Content-Type"] = "application/xml"
+        response.headers["Cache-Control"] = "public, max-age=43200"
+
+        return response
+
+    app.register_blueprint(blog, url_prefix=url_prefix)


### PR DESCRIPTION
## Done

- Integrate blog module into juju.is
- Now all the articles using the tag `juju.is` will appear on juju.is/blog

## QA

- `dotrun`
- Connect to the VPN (to get access to the blog API)
- http://0.0.0.0:8041/blog or https://juju-is-177.demos.haus/blog
- Click on the article. You should have a article page
- http://0.0.0.0:8041/blog/feed or https://juju-is-177.demos.haus/blog/feed
- You should have an RSS feed
- http://0.0.0.0:8041/blog/sitemap.xml or https://juju-is-177.demos.haus/blog/sitemap.xml
- You should have a sitemap
- To test with more articles (and pagination), replace the tag id with `2996` this will pull all snapcraft blog posts
