### PR TITLE
Add hiring link to global nav

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -140,7 +140,7 @@
     <script src="/static/js/build/global-nav/global-nav.js"></script>
     <script src="/static/js/build/cookie-policy/cookie-policy.js"></script>
     <script>
-      canonicalGlobalNav.createNav({ maxWidth: "72rem", showLogins: false });
+      canonicalGlobalNav.createNav({ maxWidth: "72rem", showLogins: false , hiring: 'https://juju.is/careers' });
       cpNs.cookiePolicy();
     </script>
   </body>


### PR DESCRIPTION
## Done

Add hiring link to the global nav

## QA

- `dotrun`
-  http://0.0.0.0:8041
- Make sure global nav has a we're hiring link to the juju.is careers page
