### PR TITLE
Use greenhouse field "Canonical site" instead of department

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -39,7 +39,7 @@ greenhouse = Greenhouse(
 
 @app.route("/careers")
 def careers():
-    vacancies = greenhouse.get_vacancies_by_department_slug("Juju")
+    vacancies = greenhouse.get_vacancies_by_site("juju.is")
     return render_template("careers.html", vacancies=vacancies)
 
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -4,6 +4,7 @@ from base64 import b64encode
 def _get_metadata(job, name):
     metadata_map = {
         "description": 2739137,
+        "Canonical site": 3209541,
     }
 
     for data in job["metadata"]:
@@ -16,8 +17,8 @@ class Vacancy:
     def __init__(self, job: dict):
         self.id: str = job["id"]
         self.title: str = job["title"]
-        self.department: str = job["departments"][0]["name"]
         self.description: str = _get_metadata(job, "description")
+        self.site: str = _get_metadata(job, "Canonical site")
 
 
 class Greenhouse:
@@ -47,13 +48,13 @@ class Greenhouse:
         return vacancies
 
     """
-    Get vacancies where the department matches a given department
+    Get vacancies where the site matches a given site
     """
 
-    def get_vacancies_by_department_slug(self, department):
+    def get_vacancies_by_site(self, site):
         vacancies = self.get_vacancies()
 
-        def department_filter(vacancy):
-            return vacancy.department == department
+        def site_filter(vacancy):
+            return site in vacancy.site if vacancy.site else False
 
-        return list(filter(department_filter, vacancies))
+        return list(filter(site_filter, vacancies))


### PR DESCRIPTION
## Done

- Use greenhouse field "Canonical site" instead of department
- This is a field that would allow recruiters to say which site the job should appear in 

## QA

- `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8041/careers
- There should be a list of jobs
