### PR TITLE
Add tutorials filtering by topics

### DIFF
--- a/static/js/tutorials-list.js
+++ b/static/js/tutorials-list.js
@@ -1,0 +1,36 @@
+(function () {
+  const topicsFilter = document.getElementById("tutorials-topic");
+  const urlObj = new URL(window.location);
+
+  function handleFilter(key, el, url) {
+    if (!el) {
+      return;
+    }
+
+    if (url.searchParams.has(key)) {
+      el.value = url.searchParams.get(key);
+    }
+
+    el.addEventListener("change", (e) => {
+      const value = e.target.value;
+
+      if (url.searchParams.has("page")) {
+        url.searchParams.delete("page");
+      }
+
+      if (value) {
+        if (url.searchParams.has(key)) {
+          url.searchParams.delete(key);
+        }
+
+        url.searchParams.append(key, value);
+      } else {
+        url.searchParams.delete(key);
+      }
+
+      window.location = url;
+    });
+  }
+
+  handleFilter("topic", topicsFilter, urlObj);
+})();

--- a/static/js/tutorials-list.js
+++ b/static/js/tutorials-list.js
@@ -5,6 +5,13 @@
     topicsFilter.addEventListener("change", (e) => {
       window.location.search = `?topic=${e.target.value}`;
     });
+
+    const params = new URLSearchParams(window.location.search);
+    const topicFromUrl = params.get("topic");
+
+    if (topicFromUrl) {
+      topicsFilter.value = topicFromUrl;
+    }
   } else {
     throw new Error(`${selector} is not a valid element!`);
   }

--- a/static/js/tutorials-list.js
+++ b/static/js/tutorials-list.js
@@ -1,36 +1,11 @@
 (function () {
-  const topicsFilter = document.getElementById("tutorials-topic");
-  const urlObj = new URL(window.location);
-
-  function handleFilter(key, el, url) {
-    if (!el) {
-      return;
-    }
-
-    if (url.searchParams.has(key)) {
-      el.value = url.searchParams.get(key);
-    }
-
-    el.addEventListener("change", (e) => {
-      const value = e.target.value;
-
-      if (url.searchParams.has("page")) {
-        url.searchParams.delete("page");
-      }
-
-      if (value) {
-        if (url.searchParams.has(key)) {
-          url.searchParams.delete(key);
-        }
-
-        url.searchParams.append(key, value);
-      } else {
-        url.searchParams.delete(key);
-      }
-
-      window.location = url;
+  const selector = "tutorials-topic";
+  const topicsFilter = document.getElementById(selector);
+  if (topicsFilter) {
+    topicsFilter.addEventListener("change", (e) => {
+      window.location.search = `?topic=${e.target.value}`;
     });
+  } else {
+    throw new Error(`${selector} is not a valid element!`);
   }
-
-  handleFilter("topic", topicsFilter, urlObj);
 })();

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -4,11 +4,29 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped is-shallow">
+<section class="p-strip--suru-topped is-shallow u-no-padding--bottom">
   <div class="u-fixed-width">
     <h1 class="p-heading--two">Tutorials</h1>
   </div>
+</section>
 
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-4">
+      <div class="p-form__group">
+        <label for="tutorials-topic">Topic:</label>
+        <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
+          <option value="">Any</option>
+          <option value="cloud">Cloud</option>
+          <option value="containers">Containers</option>
+          <option value="documentation">Documentation</option>
+          <option value="cli">CLI</option>
+        </select>
+      </div>
+    </div>
+</section>
+
+<section>
   <div class="row u-equal-height">
     {% for item in metadata %}
       {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
@@ -24,7 +42,9 @@
       {% endif %}
     {% endfor %}
   </div>
+</section>
 
+<section>
   {% if total_pages > 1 %}
   <div class="u-fixed-width">
     <ol class="p-pagination u-align--center">
@@ -111,4 +131,5 @@
   {% endif %}
 </section>
 
+<script src="{{ versioned_static('js/tutorials-list.js') }}"></script>
 {% endblock %}

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -1,12 +1,17 @@
 {% extends "base.html" %}
 
 {% block title %}Juju tutorials{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1LTpx2s2ZduhllsuRBIKPpRML5_GE9E8TNqJbvXhuz-Q{% endblock %}
 
 {% block content %}
 
 <section class="p-strip--suru-topped is-shallow u-no-padding--bottom">
   <div class="u-fixed-width">
-    <h1 class="p-heading--two">Tutorials</h1>
+    <h1 class="p-heading--two">Charmed Operator Framework Tutorials</h1>
+    <p>These tutorials cover ground from the Charmed Operator Lifecycle Manager to creating a Charmed Operator with the SDK, packaging it as a Charm, publishing it to Charmhub, and to using charmed products such as Kubernetes, Cassandra, Kafka, and much much more. </p>
+    <p>
+      <a href="/tutorials/how-to-write-a-tutorial" class="p-button--positive">Contribute a Tutorial</a>
+    </p>
   </div>
 </section>
 

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -51,7 +51,7 @@
       {% set current_page = page %}
       {% if current_page > 1 %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link--previous" href="/tutorials?page={{ current_page - 1 }}" title="Previous page">
+          <a class="p-pagination__link--previous" href="/tutorials?page={{ current_page - 1 }}{% if topic %}&topic={{ topic }}{% endif %}" title="Previous page">
             <i class="p-icon--contextual-menu">Previous page</i>
           </a>
         </li>
@@ -64,60 +64,60 @@
       {# always show 5 pages in pagination #}
       {% if current_page > 4 and current_page == total_pages %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 4 }}">{{ current_page - 4 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 4 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page - 4 }}</a>
         </li>
       {% endif %}
 
       {% if current_page > 3 and current_page >= total_pages - 1 %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 3 }}">{{ current_page - 3 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 3 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page - 3 }}</a>
         </li>
       {% endif %}
 
       {% if current_page > 2 %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 2 }}">{{ current_page - 2 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 2 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page - 2 }}</a>
         </li>
       {% endif %}
 
       {% if current_page > 1 %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 1 }}">{{ current_page - 1 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page - 1 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page - 1 }}</a>
         </li>
       {% endif %}
 
       <!-- current page -->
       <li class="p-pagination__item">
-        <a class="p-pagination__link is-active" href="/tutorials?page={{ current_page }}">{{ current_page }}</a>
+        <a class="p-pagination__link is-active" href="/tutorials?page={{ current_page }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page }}</a>
       </li>
 
       {% if current_page < total_pages %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 1 }}">{{ current_page + 1 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 1 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page + 1 }}</a>
         </li>
       {% endif %}
 
       {% if current_page < total_pages - 1 %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 2 }}">{{ current_page + 2 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 2 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page + 2 }}</a>
         </li>
       {% endif %}
 
       {% if current_page < total_pages - 2 and current_page <= 2 %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 3 }}">{{ current_page + 3 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 3 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page + 3 }}</a>
         </li>
       {% endif %}
 
       {% if current_page < total_pages - 3 and current_page == 1 %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 4 }}">{{ current_page + 4 }}</a>
+          <a class="p-pagination__link" href="/tutorials?page={{ current_page + 4 }}{% if topic %}&topic={{ topic }}{% endif %}">{{ current_page + 4 }}</a>
         </li>
       {% endif %}
 
       {% if current_page != total_pages %}
         <li class="p-pagination__item">
-          <a class="p-pagination__link--next" href="/tutorials?page={{ current_page + 1 }}" title="Next page">
+          <a class="p-pagination__link--next" href="/tutorials?page={{ current_page + 1 }}{% if topic %}&topic={{ topic }}{% endif %}" title="Next page">
             <i class="p-icon--contextual-menu">Next page</i>
           </a>
         </li>

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -24,9 +24,19 @@ def init_tutorials(app, url_prefix):
     @app.route(url_prefix)
     def index():
         page = flask.request.args.get("page", default=1, type=int)
+        topic = flask.request.args.get("topic", default=None, type=str)
         posts_per_page = 12
         tutorials_discourse.parser.parse()
-        metadata = tutorials_discourse.parser.metadata
+
+        if not topic:
+            metadata = tutorials_discourse.parser.metadata
+        else:
+            metadata = [
+                doc
+                for doc in tutorials_discourse.parser.metadata
+                if topic in doc["categories"]
+            ]
+
         total_pages = math.ceil(len(metadata) / posts_per_page)
 
         return flask.render_template(

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -48,6 +48,7 @@ def init_tutorials(app, url_prefix):
             posts_per_page=posts_per_page,
             total_pages=total_pages,
             active_section="tutorials",
+            topic=topic,
         )
 
     tutorials_discourse.init_app(app)


### PR DESCRIPTION
## Done

- Add dropdown to filter tutorials per topic
- For now I use the current topics that we have on discourse, we can add an updated version of those in a later iteration.

## QA

- `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8041/tutorials
- Play with the filters, make sure you have results for all of them.

