### PR TITLE
Add sdk docs to juju.is

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -122,7 +122,7 @@ template_finder_view = TemplateFinder.as_view("template_finder")
 app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
-init_docs(app, "/docs")
+init_docs(app)
 init_tutorials(app, "/tutorials")
 init_blog(app, "/blog")
 

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -5,7 +5,7 @@ from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
 from canonicalwebteam.search import build_search_view
 
 
-def init_docs(app, url_prefix):
+def init_docs(app):
     discourse_index_id = 1087
 
     session = talisker.requests.get_session()
@@ -15,13 +15,29 @@ def init_docs(app, url_prefix):
                 base_url="https://discourse.charmhub.io/", session=session
             ),
             index_topic_id=discourse_index_id,
-            url_prefix=url_prefix,
+            url_prefix="/docs",
         ),
         document_template="docs/document.html",
-        url_prefix=url_prefix,
+        url_prefix="/docs",
     )
 
     discourse_docs.init_app(app)
+
+    sdk_docs_id = 4449
+    sdk_docs = Docs(
+        parser=DocParser(
+            api=DiscourseAPI(
+                base_url="https://discourse.charmhub.io/", session=session
+            ),
+            index_topic_id=sdk_docs_id,
+            url_prefix="/docs/sdk",
+        ),
+        document_template="docs/document.html",
+        url_prefix="/docs/sdk",
+        blueprint_name="sdk_docs",
+    )
+
+    sdk_docs.init_app(app)
 
     app.add_url_rule(
         "/docs/search",


### PR DESCRIPTION
## Done

- Add new set of sdk documentation

## QA

- `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8041/docs/sdk
