### PR TITLE
update Vanilla to 2.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postcss": "8.2.9",
     "postcss-cli": "8.3.1",
     "sass-lint": "1.13.1",
-    "vanilla-framework": "2.27.0",
+    "vanilla-framework": "2.28.0",
     "watch-cli": "0.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2649,10 +2649,10 @@ vanilla-framework@2.19.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
   integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
 
-vanilla-framework@2.27.0:
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.27.0.tgz#4091a50aaae1de23c3345441ccad8de778208150"
-  integrity sha512-/j+ocFSrjxkr2QTxogFM8WXKIg718RMBfU/l14nLq290//n1vf1SCeO6kApMkbEUmijjSBCiAhemQ5IhVzwJdA==
+vanilla-framework@2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.28.0.tgz#45f729d0e2d863e0aeceab4589a8e0d310f8c9df"
+  integrity sha512-EjrPn1sBFRZ+e6OyVgDIl8Nvdb3xxihodTD+L/FgQSiJJREGLmLjC+NZhq4xziNgHedzDZbIC8Qlx8B4SIo41g==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Bumped version to 2.28.0 (mostly because it includes [a fix](https://github.com/canonical-web-and-design/vanilla-framework/pull/3698) for an issue I'm having in a different branch)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- There are no breaking changes in the release, but browse the site and compare to [live](https://juju.is), see that nothing is broken.
