### PR TITLE
Fix learn to be highlighted when on /docs/sdk

### DIFF
--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -43,7 +43,7 @@
         <li class="p-navigation__item{% if request.path.startswith('/blog') %} is-selected{% endif %}">
           <a class="p-navigation__link" href="/blog">Blog</a>
         </li>
-        <li class="p-navigation__item p-subnav{% if request.path in [ '/docs', '/tutorials'] %} is-selected{% endif %}" id="learn-link">
+        <li class="p-navigation__item p-subnav{% if request.path in [ '/docs', '/docs/sdk', '/tutorials'] %} is-selected{% endif %}" id="learn-link">
           <a href="#learn-link-menu" aria-controls="learn-link-menu" class="p-subnav__toggle p-navigation__link">Learn</a>
           <ul class="p-subnav__items" id="learn-link-menu" aria-hidden="true">
             <li>


### PR DESCRIPTION
## Done

- Fix learn to be highlighted when on /docs/sdk

## QA

- Go to https://juju-is-200.demos.haus/docs/sdk and see that `Learn` is orange in the navigation


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
