### PR TITLE
Update docs and tutorials

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -19,6 +19,16 @@ env:
       key: greenhouse_api_key
       name: canonical-com
 
+  - name: DISCOURSE_API_KEY
+    secretKeyRef:
+      key: charmhub-api-key
+      name: discourse-api
+
+  - name: DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: charmhub-api-username
+      name: discourse-api
+
 # Overrides for production
 production:
   replicas: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.flask-base==0.9.0
 canonicalwebteam.yaml-responses==1.1.1
-canonicalwebteam.discourse==3.0.8
+canonicalwebteam.discourse==4.0.0
 canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -38,12 +38,14 @@
 
 <section>
   <div class="row u-equal-height">
-    {% for item in metadata %}
+    {% for item in tutorials %}
       {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
         <div class="col-4 col-medium-3 p-card">
           <div class="p-card__content">
             <h3 class="p-heading--four">
-              {{ item.topic | safe }}
+              <a class="inline-onebox" href="{{ item.link }}">
+                {{ item.title | safe }}
+              </a>
             </h3>
             <p>{{ item.summary | safe }}</p>
           </div>

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -1,21 +1,33 @@
+from os import getenv
+
 import talisker.requests
 
 from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
-
 from canonicalwebteam.search import build_search_view
+
+DISCOURSE_API_KEY = getenv("DISCOURSE_API_KEY")
+DISCOURSE_API_USERNAME = getenv("DISCOURSE_API_USERNAME")
 
 
 def init_docs(app):
     discourse_index_id = 1087
+    tutorials_index_topic_id = 2628
+    tutorials_url_prefix = "/tutorials"
 
     session = talisker.requests.get_session()
     discourse_docs = Docs(
         parser=DocParser(
             api=DiscourseAPI(
-                base_url="https://discourse.charmhub.io/", session=session
+                base_url="https://discourse.charmhub.io/",
+                session=session,
+                api_key=DISCOURSE_API_KEY,
+                api_username=DISCOURSE_API_USERNAME,
+                get_topics_query_id=2,
             ),
             index_topic_id=discourse_index_id,
             url_prefix="/docs",
+            tutorials_index_topic_id=tutorials_index_topic_id,
+            tutorials_url_prefix=tutorials_url_prefix,
         ),
         document_template="docs/document.html",
         url_prefix="/docs",
@@ -27,10 +39,16 @@ def init_docs(app):
     sdk_docs = Docs(
         parser=DocParser(
             api=DiscourseAPI(
-                base_url="https://discourse.charmhub.io/", session=session
+                base_url="https://discourse.charmhub.io/",
+                session=session,
+                api_key=DISCOURSE_API_KEY,
+                api_username=DISCOURSE_API_USERNAME,
+                get_topics_query_id=2,
             ),
             index_topic_id=sdk_docs_id,
             url_prefix="/docs/sdk",
+            tutorials_index_topic_id=tutorials_index_topic_id,
+            tutorials_url_prefix=tutorials_url_prefix,
         ),
         document_template="docs/document.html",
         url_prefix="/docs/sdk",


### PR DESCRIPTION
## Done

- Update plugin to the new version that uses the Discourse Data Explorer plugin
- Link to tutorials inside the documentation pages

## QA

- `dotrun`
- Check http://0.0.0.0:8041/tutorials
- Check there is a tutorial card at the end of the page in http://0.0.0.0:8041/docs/charm-bundles

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1984, https://github.com/canonical-web-and-design/snap-squad/issues/1986

## Blocked by
https://github.com/canonical-web-and-design/canonicalwebteam.discourse/pull/100
