### PR TITLE
Add marketo form to /about

### DIFF
--- a/templates/about/_ebook-signup-form.html
+++ b/templates/about/_ebook-signup-form.html
@@ -1,5 +1,4 @@
-<!-- TODO: append marketo form ID to ID attribute-->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_" class="marketo-form">
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3875" class="marketo-form">
   <label for="Email" class="mktoLabel ">Email address:</label>
   <input required  id="email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
   
@@ -7,16 +6,14 @@
     You'll receive an email with a link to get your t-shirt.
   </p> 
 
-  <!-- TODO: add marketo form ID to value attribute-->
-  <input type="hidden" name="formid" class="mktoField" value="">
-  <input type="hidden" name="formVid" class="mktoField" value="">
+  <input type="hidden" name="formid" class="mktoField" value="3875">
+  <input type="hidden" name="formVid" class="mktoField" value="3875">
 
   <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
   <input type="hidden" name="Consent_to_Processing__c" value="yes" />
   <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
 
-  <!-- TODO: add ebook URL to value attribute -->
-  <input type="hidden" name="returnURL" value="" />
+  <input type="hidden" name="returnURL" value="{{ request.url}}?form_success=true#send-us-your-details" />
 
   <button type="submit" class="p-button--positive u-no-margin--bottom" aria-label="Submit">Get the eBook</button>
 </form>

--- a/templates/about/_ebook-signup-form.html
+++ b/templates/about/_ebook-signup-form.html
@@ -1,0 +1,22 @@
+<!-- TODO: append marketo form ID to ID attribute-->
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_" class="marketo-form">
+  <label for="Email" class="mktoLabel ">Email address:</label>
+  <input required  id="email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+  
+  <p class="p-form-help-text u-sv1">
+    You'll receive an email with a link to get your t-shirt.
+  </p> 
+
+  <!-- TODO: add marketo form ID to value attribute-->
+  <input type="hidden" name="formid" class="mktoField" value="">
+  <input type="hidden" name="formVid" class="mktoField" value="">
+
+  <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
+  <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+  <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+
+  <!-- TODO: add ebook URL to value attribute -->
+  <input type="hidden" name="returnURL" value="" />
+
+  <button type="submit" class="p-button--positive u-no-margin--bottom" aria-label="Submit">Get the eBook</button>
+</form>

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -58,7 +58,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-5">
-      <h2>Get the eBook and a t-shirt</h2>
+      <h2>Get the eBook and a chance to win a t-shirt</h2>
       <h3 class="p-heading--4">From Configuration to Application Management:</h3>
 
       <p>The SRE’s Guide to Taking Control of Applications and Services in a Hybrid Cloud World</p>
@@ -80,9 +80,15 @@
           loading="lazy",
         ) | safe
       }}
-      <h3 class="p-heading--4">Send us your details</h3>
+      <h3 id="send-us-your-details" class="p-heading--4">Send us your details</h3>
       
-      {% include 'about/_ebook-signup-form.html' %}
+      {% if 'form_success' in request.args %}
+        <div class="p-notification--positive">
+          <p class="p-notification__response"><span class="p-notification__status">Success:</span> Thank you for your entry, you'll receive an email very soon.</p>
+        </div>
+      {% else %}
+        {% include 'about/_ebook-signup-form.html' %}
+      {% endif %}
     </div>
   </div>
 </section>

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -72,7 +72,7 @@
     <div class="col-4 col-start-large-7">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/ac5fc4e3-charming-tshirt.jpg",
+          url="https://assets.ubuntu.com/v1/ec0a68a4-charming-t-shirt.jpg",
           alt="",
           height="298",
           width="760",

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -82,16 +82,7 @@
       }}
       <h3 class="p-heading--4">Send us your details</h3>
       
-      <form>
-        <label for="Email">Email address:</label>
-        <input disabled required type="email" value="Coming soon" />
-        
-        <p class="p-form-help-text u-sv1">
-          You'll receive an email with a link to get your t-shirt.
-        </p> 
-
-        <button type="submit" disabled class="p-button--positive u-no-margin--bottom" aria-label="Submit">Get the eBook</button>
-      </form>
+      {% include 'about/_ebook-signup-form.html' %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

**Blocked until we get the ebook URL and Marketo form ID**

Added Marketo form to /about

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- At the bottom of the page, fill in the form, click submit, see that you are taken to the ebook PDF


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2008
