### PR TITLE
Add support for links on level 0 docs nav items

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -46,8 +46,16 @@
             </a>
           </div>
           {% for nav_group in navigation.nav_items %}
-            {% if nav_group.navlink_text %}
-            <h3>{{ nav_group.navlink_text }}</h3>
+            {% if nav_group.navlink_href %}
+              <h3>
+                <a 
+                  class="p-link--soft"
+                  href="{{ nav_group.navlink_href }}" 
+                  {% if request.path == nav_group.navlink_href %}aria-current="page"{% endif %}
+                >{{ nav_group.navlink_text }}</a>
+            </h3>
+            {% elif nav_group.navlink_text %}
+               <h3>{{ nav_group.navlink_text }}</h3>
             {% endif %}
             {{ create_navigation(nav_group.children) }}
           {% endfor %}


### PR DESCRIPTION
## Done

Added ability for level 0 items to become links if a href value is present

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041/docs
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #193 
