### PR TITLE
Fix navigation js not to use ES6

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -77,9 +77,11 @@
         // ask the observer to observe the position of the observerEl - i.e. if it's on/off screen
         observer.observe(observerEl);
       } else {
-        throw new Error(
-          `${selector ? selector : "#navigation"} is not a valid element!`
-        );
+        if (selector) {
+          console.error(selector + " is not a valid element!");
+        } else {
+          console.error("#navigation is not a valid element!");
+        }
       }
     })
   </script>

--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -38,7 +38,7 @@
     <nav class="p-navigation__nav">
       <ul class="p-navigation__items">
         <li class="p-navigation__item{% if request.path.startswith('/about') %} is-selected{% endif %}">
-          <a class="p-navigation__link" href="/mission">About</a>
+          <a class="p-navigation__link" href="/about">About</a>
         </li>
         <li class="p-navigation__item{% if request.path.startswith('/blog') %} is-selected{% endif %}">
           <a class="p-navigation__link" href="/blog">Blog</a>


### PR DESCRIPTION
## Done

- Fix navigation js not to use ES6
- Point to `/about` whe you click About in the nav

## QA

- Go to https://juju-is-209.demos.haus and click on About and see you are taken to `/about`


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
