### PR TITLE
Add juju supports logos

### DIFF
--- a/templates/partials/_juju-supports.html
+++ b/templates/partials/_juju-supports.html
@@ -24,19 +24,74 @@
                   <hr />
                   <ul class="row u-no-margin--bottom">
                     <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      <a href="https://juju.is/docs/aws-cloud"><img src="https://assets.ubuntu.com/v1/83ff4203-awshp-strip-customers.png" alt="Amazon Web Services logo"></a>
+                      <a href="https://juju.is/docs/aws-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/f4b0487e-aws-logo.svg",
+                            alt="Amazon Web Services logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/azure-cloud"><img src="https://assets.ubuntu.com/v1/7c601cb9-azurehp-strip-customers.png" alt="Microsoft Azure logo"></a>
+                      <a href="https://juju.is/docs/azure-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/35e4c3fb-microsoft-azure-logo.svg",
+                            alt="Microsoft Azure logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/gce-cloud"><img src="https://assets.ubuntu.com/v1/fdb8126b-google+cloudhp-strip-customers.png" alt="Google Cloud logo"></a>
+                      <a href="https://juju.is/docs/gce-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/57e46e3b-google-logo.svg",
+                            alt="Google Cloud logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2 col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/oci-cloud"><img src="https://assets.ubuntu.com/v1/5ba04ee8-atthp-strip-customers.png" alt="AT&amp;T logo"></a>
+                      <a href="https://juju.is/docs/oci-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/62c0c762-oracle-logo.svg",
+                            alt="Oracle logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2 col-start-small-2">
-                      <a href="https://juju.is/docs/rackspace-cloud"><img src="https://assets.ubuntu.com/v1/3faca6ca-netflixhp-strip-customers.png" alt="Netflix logo"></a>
+                      <a href="https://juju.is/docs/rackspace-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/50aef2d0-rackspace-logo.svg",
+                            alt="Rackspace logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                   </ul>
                 </div>
@@ -54,16 +109,60 @@
                   <hr />
                   <ul class="row u-no-margin--bottom">
                     <li class="col-2 col-medium-2 col-small-2 col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/vsphere-cloud"><img src="https://assets.ubuntu.com/v1/83ff4203-awshp-strip-customers.png" alt="Amazon Web Services logo"></a>
+                      <a href="https://juju.is/docs/vsphere-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/bc0dcda4-vmware-logo.svg",
+                            alt="vmware logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/openstack-cloud"><img src="https://assets.ubuntu.com/v1/7c601cb9-azurehp-strip-customers.png" alt="Microsoft Azure logo"></a>
+                      <a href="https://juju.is/docs/openstack-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/123fa920-openstack-logo.svg",
+                            alt="Openstack logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2  col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/maas-cloud"><img src="https://assets.ubuntu.com/v1/5ba04ee8-atthp-strip-customers.png" alt="AT&amp;T logo"></a>
+                      <a href="https://juju.is/docs/maas-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/8dc96822-maas-logo.svg",
+                            alt="MAAS logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/manual-cloud"><img src="https://assets.ubuntu.com/v1/fdb8126b-google+cloudhp-strip-customers.png" alt="Google Cloud logo"></a>
+                      <a href="https://juju.is/docs/manual-cloud">
+                        {{
+                          image(                        
+                            url="https://assets.ubuntu.com/v1/cf9550e3-managed-cloud-logo.svg",
+                            alt="manual cloud logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                   </ul>
                 </div>
@@ -81,19 +180,74 @@
                   <hr />
                   <ul class="row u-no-margin--bottom">
                     <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      <a href="https://juju.is/docs/microk8s-cloud"><img src="https://assets.ubuntu.com/v1/83ff4203-awshp-strip-customers.png" alt="Amazon Web Services logo"></a>
+                      <a href="https://juju.is/docs/microk8s-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/89fdda84-microk8s-logo.svg",
+                            alt="MicroK8s logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/kubernetes/azure-aks"><img src="https://assets.ubuntu.com/v1/7c601cb9-azurehp-strip-customers.png" alt="Microsoft Azure logo"></a>
+                      <a href="https://juju.is/docs/kubernetes/azure-aks">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/35e4c3fb-microsoft-azure-logo.svg",
+                            alt="Microsoft Azure logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/kubernetes/amazon-eks"><img src="https://assets.ubuntu.com/v1/5ba04ee8-atthp-strip-customers.png" alt="AT&amp;T logo"></a>
+                      <a href="https://juju.is/docs/kubernetes/amazon-eks">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/f4b0487e-aws-logo.svg",
+                            alt="AWS logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2 col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/kubernetes/google-gke"><img src="https://assets.ubuntu.com/v1/fdb8126b-google+cloudhp-strip-customers.png" alt="Google Cloud logo"></a>
+                      <a href="https://juju.is/docs/kubernetes/google-gke">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/57e46e3b-google-logo.svg",
+                            alt="Google Cloud logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                     <li class="col-2 col-medium-2 col-small-2 col-start-small-2">
-                      <a href="https://juju.is/docs/kubernetes"><img src="https://assets.ubuntu.com/v1/3faca6ca-netflixhp-strip-customers.png" alt="Netflix logo"></a>
+                      <a href="https://juju.is/docs/kubernetes">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/d789eb54-k8s-logo.svg",
+                            alt="Kubernetes logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                   </ul>
                 </div>
@@ -111,7 +265,18 @@
                   <hr />
                   <ul class="row u-no-margin--bottom">
                     <li class="col-2 col-medium-2 col-small-2 col-start-large-4 col-start-medium-3 col-start-small-2">
-                      <a href="https://juju.is/docs/lxd-cloud"><img src="https://assets.ubuntu.com/v1/83ff4203-awshp-strip-customers.png" alt="Amazon Web Services logo"></a>
+                      <a href="https://juju.is/docs/lxd-cloud">
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/73d1829d-lxd-logo.svg",
+                            alt="LXD logo",
+                            height="144",
+                            width="145",
+                            hi_def=True,
+                            loading="eager",
+                          ) | safe
+                        }}
+                      </a>
                     </li>
                   </ul>
                 </div>
@@ -129,22 +294,76 @@
                   <hr />
                   <ul class="row u-no-margin--bottom u-align-text--center">
                     <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      K8s
+                      {{
+                        image(
+                          url="https://assets.ubuntu.com/v1/d789eb54-k8s-logo.svg",
+                          alt="k8s logo",
+                          height="144",
+                          width="145",
+                          hi_def=True,
+                          loading="eager",
+                        ) | safe
+                      }}
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      Linux
+                      {{
+                        image(
+                          url="https://assets.ubuntu.com/v1/e26901ed-linux-logo.svg",
+                          alt="Linux logo",
+                          height="144",
+                          width="145",
+                          hi_def=True,
+                          loading="eager",
+                        ) | safe
+                      }}
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      Windows
+                      {{
+                        image(
+                          url="https://assets.ubuntu.com/v1/70655b4b-windows-logo.svg",
+                          alt="Windows logo",
+                          height="144",
+                          width="145",
+                          hi_def=True,
+                          loading="eager",
+                        ) | safe
+                      }}
                     </li>
                     <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      SAAS
+                      {{
+                        image(
+                          url="https://assets.ubuntu.com/v1/b88d48be-saas-logo.svg",
+                          alt="saas logo",
+                          height="144",
+                          width="145",
+                          hi_def=True,
+                          loading="eager",
+                        ) | safe
+                      }}
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      Physical Appliances
+                      {{
+                        image(
+                          url="https://assets.ubuntu.com/v1/27c4bde6-appliance-logo.svg",
+                          alt="physical appliance logo",
+                          height="144",
+                          width="145",
+                          hi_def=True,
+                          loading="eager",
+                        ) | safe
+                      }}
                     </li>
                     <li class="col-2 col-medium-2 col-small-2">
-                      Uncharmed Software
+                      {{
+                        image(
+                          url="https://assets.ubuntu.com/v1/9af66a46-software-logo.svg",
+                          alt="uncharmed software logo",
+                          height="144",
+                          width="145",
+                          hi_def=True,
+                          loading="eager",
+                        ) | safe
+                      }}
                     </li>
                   </ul>
                 </div>


### PR DESCRIPTION
## Done

Added correct logos to "Juju supports" carousel

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Scroll down to the "Juju supports" section, see that the logos are relevant to their links


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2042
