### PR TITLE
Add model driven operations manifesto

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -89,7 +89,7 @@
           <a class="p-link--soft" href="#"><small>Best Practices for creating charms</small></a>
         </li>
         <li class="p-list__item">
-          <a class="p-link--soft" href="#"><small>Model Driven Operations Manifesto</small></a>
+          <a class="p-link--soft" href="/model-driven-operations-manifesto"><small>Model Driven Operations Manifesto</small></a>
         </li>
         <li class="p-list__item">
           <a class="p-link--soft" href="#"><small>Why Helm and Kustomize Aren’t Enough: the Future</small> of Kubernetes Apps</a>

--- a/templates/model-driven-operations-manifesto.html
+++ b/templates/model-driven-operations-manifesto.html
@@ -1,0 +1,138 @@
+{% extends 'base.html' %}
+
+{% block title %}The Open Operator Manifesto{% endblock title %}
+
+{% block meta_description %}We lead the Open Operator Collection, on a mission to elevate the art of dev&ndash;sec&ndash;ops with open&ndash;source operators that control enterprise applications{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1bPFekWN4xrUue2l8F2_2w3ygnh06VHMA3VUVoTzuAFk{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+    <h1>The Open Operator Manifesto</h1>
+    <h2 class="p-heading--4 u-sv3" style="max-width: 40rem;">Better operators through open community standards</h2>
+    <p>Our goal is to improve devsecops with open source operators for widely used software. These shared values ensure high quality code and conversations.</p>
+  </div>  
+</section>
+<section class="row">
+  <div class="col-8">
+    <ol class="p-list--ordered is-h4">
+      <li>
+        Source required
+        <p>We make operator source available so that everybody can understand exactly what happens on their systems.</p>
+      </li>
+      <li>
+        Open source preferred
+        <p>We are an open source community to enable everyone to contribute to common app operations. Our frameworks and tools are open source, but our framework license does allow vendors to create interoperable operators with their own license.</p>
+      </li>
+      <li>
+        Community-driven
+        <p>An operator distills real-world application experience into shared code. No one person can know all the ways an app will be used. Open community discussions and code are the best way to improve operator performance, usability, quality and completeness.</p>
+      </li>
+      <li>
+        Security
+        <p>An operator should apply defense-in-depth to every aspect of operations &mdash; from data encryption and app confinement to password selection and key handling. We review all operators for security, and we publish fixes fast.</p>
+      </li>
+      <li>
+        Multi-cloud optimisation
+        <p>An operator should work on every cloud or Kubernetes, and should also automatically optimise for its environment and take advantage of local, differentiated capabilities.</p>
+      </li>
+      <li>
+      Reusability
+      <p>Reuse improves quality and grows the community. An operator should offer many ways to deploy the application &mdash; large or small scale, resilient or minimal, persistent or ephemeral, standalone or integrated with as many other apps as possible.</p>
+      </li>
+      <li>
+       Patches
+       <p>Operators should facilitate security patching, to help administrators maintain a healthy and compliant deployment. High-quality updates are essential for security.</p>
+      </li>
+      <li>
+        Upgradability
+        <p>Operators should manage upgrades. An operator should ensure maximum availability throughout the upgrade and provide a way to roll back to prior state.</p>
+      </li>
+      <li>
+       High-level config
+       <p>Operators should abstract complex application configuration. An operator should offer only high-level config to capture admin intent and reduce the burden of application specific domain expertise required to run the app.</p>
+      </li>
+      <li>
+        Scalability
+        <p>Applications are often clustered for resilience or performance. An operator should handle dynamic changes, optimise for admin intent, and scale up or down equally well.</p>
+      </li>
+      <li>
+        Everyday actions included
+       <p>Daily actions like backup, restore, reset, and restart should never require direct admin access to underlying systems or containers. Actions should be driven by API or CLI, subject to permissions, and logged for audit and accountability.</p>
+      </li>
+      <li>
+        Status
+       <p>Admins should never require direct access to underlying systems or containers to know the status of a workload. An operator should assess and represent the health, availability, and dependencies of the app.</p>
+      </li>
+      <li>
+       Leadership
+        <p>In distributed systems, problems occur if different units of the same app make conflicting decisions. An operator should provide leadership and communicate leader decisions to all units in a reliable way with proven consistency.</p>
+      </li>
+      <li>
+        Subordinate software
+        <p>An operator should provide for related functions to coexist in its execution environment, whether that is a Kubernetes pod or a machine.</p>
+      </li>
+      <li>
+        Application graph
+        <p>Most of the work in enterprise software operations is integration. An operator should go beyond the application lifecycle to the application graph, and enable integration with as many other applications as possible to support as many scenarios as possible.</p>
+      </li>
+      <li>
+       Interoperability
+       <p>Enterprises require multi-vendor deployments to work well. Operators should work well with operators from other vendors and publishers. Collaboration is best done in a public forum to ensure the widest participation.</p>
+      </li>
+      <li>
+       Consistency
+       <p>It is easier to use new applications if they follow common patterns. An operator should use common conventions to simplify the learning and adoption curve.</p>
+      </li>
+      <li>
+        Substitution
+        <p>Enterprises expect to choose the actual implementation of services in a deployment. Operators should not assume specific integration counterparts, to allow substitution with compatible alternatives.</p>
+      </li>
+      <li>
+        Model-driven
+        <p>Applications must work together to be successful. Operators should respond to changes in a shared model that describes the whole application graph and config.</p>
+      </li>
+      <li>
+        Capacity agnostic
+        <p>Admins may deploy the application on a few small machines, or many large machines. An operator should not assume capacity or scale, but learn it from the model.</p>
+      <li>
+        Network Agnostic
+        <p>Different scenarios require different networking for the same application. An operator should support segregated network architecture as described in the model.</p>
+      </li>
+      <li>
+        Cross platform
+        <p>Enterprises have applications on both Windows and Linux, and many deployments integrate platforms. The operator framework should enable multi-platform scenarios.</p>
+      </li>
+      <li>
+        Multi-arch
+        <p>An operator should work on all supported architectures of the application.</p>
+      </li>
+      <li>
+       Tested
+       <p>Operators are privileged software dealing with critical apps in sensitive environments. An operator should have both unit and integration tests that gate all changes.</p>
+      </li>
+      <li>
+        Trusted builds
+        <p>An operator should be built in a trusted environment, just like the app it drives, to guarantee provenance and integrity.</p>
+      </li>
+      <li>
+        Signed
+        <p>Operators are privileged software in which users place great trust. An operator should be signed to know who produced it, and prove that it has not been modified.</p>
+      </li>
+      <li>
+        Beta testing
+        <p>An operator should publish beta and release candidate versions to enable widespread testing and increase the quality of stable releases.</p>
+      </li>
+      <li>
+        Managed
+        <p>An enterprise environment must plan changes. Operators should enable fine-grained control of updates and enterprise control of application versions.</p>
+      </li>
+    </ol>
+    <p>
+      Operators that embrace these principles, practices and values are better for a wider audience. We elevate the art of application management with universal, open operators that reflect the deepest insights from the broadest community in the widest contexts.
+    </p>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Done

- Move manifesto from charmhub to model driven operations manifesto on juju.is

## QA

- `dotrun`
- http://0.0.0.0:8041/model-driven-operations-manifesto or https://juju-is-212.demos.haus/model-driven-operations-manifesto