### PR TITLE
Add manifesto in navigation

### DIFF
--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -43,7 +43,7 @@
         <li class="p-navigation__item{% if request.path.startswith('/blog') %} is-selected{% endif %}">
           <a class="p-navigation__link" href="/blog">Blog</a>
         </li>
-        <li class="p-navigation__item p-subnav{% if request.path in [ '/docs', '/docs/sdk', '/docs/sdk/publishing', '/tutorials'] %} is-selected{% endif %}" id="learn-link">
+        <li class="p-navigation__item p-subnav{% if request.path in [ '/docs', '/docs/sdk', '/docs/sdk/publishing', '/tutorials', '/model-driven-operations-manifesto'] %} is-selected{% endif %}" id="learn-link">
           <a href="#learn-link-menu" aria-controls="learn-link-menu" class="p-subnav__toggle p-navigation__link">Learn</a>
           <ul class="p-subnav__items" id="learn-link-menu" aria-hidden="true">
             <li>
@@ -57,6 +57,9 @@
             </li>
             <li>
               <a href="/tutorials" class="p-subnav__item">Tutorials</a>
+            </li>
+            <li>
+              <a href="/model-driven-operations-manifesto" class="p-subnav__item">Model driven operations manifesto</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
## Done

![image](https://user-images.githubusercontent.com/2707508/116537357-0715b000-a8de-11eb-8e57-1d90f6b5dd8d.png)

Add manifesto in navigation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
-  Make sure navigation is updated
- http://0.0.0.0:8041/model-driven-operations-manifesto
- Make sure learn is higlighted
