### PR TITLE
Add featured articles

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -43,7 +43,8 @@
   {% endif %}
 
   <div class="row u-clearfix">
-    {% for article in articles %}
+    {% set all_articles = featured_articles + articles %}
+    {% for article in all_articles %}
       {% if current_page == 1 and loop.index == 3 %}
         <div class="col-4 col-medium-3">
           {% include 'blog/_newsletter-signup.html' %}


### PR DESCRIPTION
## Done
By default the articles returned by the blog module is not including the featured articles

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041/blog
- This article should be on the list of articles: /blog/easily-deploy-and-manage-mattermost-on-kubernetes-with-juju-charmed-operator
