### PR TITLE
Update blog link for terraform

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -70,7 +70,7 @@
           <a class="p-link--soft" href="/blog/ansible-vs-terraform-vs-juju-fight-or-cooperation"><small>Ansible alternative</small></a>
         </li>
         <li class="p-list__item">
-          <a class="p-link--soft" href="/blog/ansible-vs-terraform-vs-juju-fight-or-cooperation"><small>Terraform alternative</small></a>
+          <a class="p-link--soft" href="/blog/juju-vs-infrastructure-as-code-tools"><small>Terraform alternative</small></a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

Update blog link for terraform

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
-  Make sure in footer terrafom link is linking to: https://juju.is/blog/juju-vs-infrastructure-as-code-tools
