### PR TITLE
Make the what is juju animation responsive to the font size

### DIFF
--- a/static/sass/_patterns_what-is-juju.scss
+++ b/static/sass/_patterns_what-is-juju.scss
@@ -57,14 +57,9 @@
       &[data-stage="5"] {
         .p-feature__illustration {
           position: fixed;
-          right: calc(calc(100vw - #{$grid-max-width}) * .56);
+          right: calc(calc(100vw - #{$grid-max-width}) * .535);
           top: 23%;
-          width: 820px;
-
-          @media only screen and (min-width: 1681px) {
-            width: 922.5px;
-            right: calc(calc(100vw - #{$grid-max-width}) * .535);
-          }
+          width: 51.2em;
         }
       }
 


### PR DESCRIPTION
## Done
Switch to using em for positioning has this will change with font-size zooming.

## QA
- Check out the demo
- Scroll down and check the animation lock into place as before
- Go to browser settings and change zoom to "Font-only"
- Refresh the demo and zoom in twice. Hard refresh and scroll through the animation
- Do the same on zooming in twice

## Issue / Card
Fixes https://github.com/canonical-web-and-design/juju.is/issues/231

