### PR TITLE
Fix tutorial page

### DIFF
--- a/static/sass/_patterns_tutorials.scss
+++ b/static/sass/_patterns_tutorials.scss
@@ -1,0 +1,53 @@
+@mixin p-tutorials {
+  .p-tutorial__nav-title {
+    padding-left: 2rem;
+    position: relative;
+
+    &::before {
+      height: $sp-large;
+      left: 0;
+      margin-right: $sp-medium;
+      position: absolute;
+      width: $sp-large;
+    }
+
+    .is-active & {
+      font-weight: 400;
+
+      &::before {
+        background-color: $color-brand;
+        color: $color-x-light;
+        font-weight: 300;
+      }
+    }
+  }
+
+  .p-tutorial__nav-link {
+    color: $color-dark;
+
+    &:visited {
+      color: $color-dark;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .p-tutorial-content {
+    margin-top: 0;
+
+    @media (min-width: $breakpoint-large) {
+      margin-top: -20rem;
+    }
+  }
+
+  .p-tutorial-section {
+    display: none;
+
+    &:target {
+      display: block;
+      padding-top: 20rem;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -56,6 +56,10 @@ $color-accent: #e95420;
 @import "patterns_l-fluid-breakout";
 @include l-juju-fluid-breakout;
 
+@import "patterns_tutorials";
+
+@include p-tutorials;
+
 .p-navigation__logo {
   margin: 0.1rem 1rem 0 1.5rem;
 }

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -28,7 +28,7 @@
       </ol>
     </nav>
   </aside>
-  <div class="l-docs-content">
+  <div class="l-docs-content p-tutorial-content">
     <div class="p-strip is-shallow">
       <div class="l-docs-row">
         {% for section in document.sections %}


### PR DESCRIPTION
## Done
- Fixed the number styles on the tutorial navigation
- Fixed the hidden navigation when clicking a tutorial step

## QA
- Go to https://juju-is-245.demos.haus/tutorials/deploy-postgres-on-ubuntu-server
- Check that the numbers on the left navigation are circles
- Click a navigation link
- Check that it isn't hidden under the sticky header

## Issue
Fixes #230, #239