### PR TITLE
Fix pagination arrows on tutorials

### DIFF
--- a/static/sass/_patterns_tutorials.scss
+++ b/static/sass/_patterns_tutorials.scss
@@ -46,4 +46,16 @@
       padding-top: 20rem;
     }
   }
+
+  .p-tutorial__pagination-item--prev {
+    .p-icon--contextual-menu {
+      transform: rotate(90deg);
+    }
+  }
+
+  .p-tutorial__pagination-item--next {
+    .p-icon--contextual-menu {
+      transform: rotate(-90deg);
+    }
+  }
 }


### PR DESCRIPTION
## Done
- Fixed the prev/next pagination arrows on tutorials

## QA
- Go to https://juju-is-251.demos.haus/tutorials/get-started-charmed-kubernetes#1-overview
- Check that the prev/next pagination arrows are facing in the right direction

## Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2083