### PR TITLE
Fix header height

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@canonical/cookie-policy": "3.2.0",
-    "@canonical/global-nav": "2.4.5",
+    "@canonical/global-nav": "2.5.0",
     "autoprefixer": "10.2.6",
     "concurrently": "6.2.0",
     "flickity": "2.2.2",

--- a/static/sass/_patterns_navigation.scss
+++ b/static/sass/_patterns_navigation.scss
@@ -179,6 +179,7 @@
   }
 
   .p-navigation__image {
+    display: block;
     max-height: none;
     max-width: none;
   }


### PR DESCRIPTION
## Done
- Fixed the header height to match charmhub.io
- Updated the global nav

## QA
- Go to https://juju-is-255.demos.haus/
- Open https://charmhub.io in a second tab
- Toggle between the two and check that the headers are the same height
- You can also use dev tools to measure both headers

## Issue
Fixes #254 