### PR TITLE
Fix docs headers being hidden by sticky header

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -207,3 +207,8 @@ h3 {
     max-width: 30rem;
   }
 }
+
+// Fixes docs headings being hidden under sticky header
+[id^="heading--"] {
+  scroll-margin-top: 60px;
+}


### PR DESCRIPTION
## Done
Fix headings in docs being hidden under the fixed header

## QA
- Go to https://juju-is-257.demos.haus/docs/olm/controller-backups
- Click on any of the links under "This page covers the following topics:" to jump to sections
- Check that the headings for each section are not hidden under the fixed header

## Issue
Fixes #256 