### PR TITLE
Update discourse docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==0.9.0
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.yaml-responses==1.2.0
-canonicalwebteam.discourse==4.0.2
+canonicalwebteam.discourse==4.0.3
 canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
## Blocked by
**Please review first:** https://github.com/canonical-web-and-design/canonicalwebteam.discourse/pull/104

## Done

- Update discourse docs

## QA
**No demo for this PR**
- Check the navigation links on the documentation pages work:
- http://0.0.0.0:8041/docs/sdk/
- At the bottom of the navigation: Github, API documentation


## Issue / Card

Fixes #258
