### PR TITLE
Update manifesto title

### DIFF
--- a/templates/model-driven-operations-manifesto.html
+++ b/templates/model-driven-operations-manifesto.html
@@ -10,7 +10,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-    <h1>The Open Operator Manifesto</h1>
+    <h1>The Model Driven Operator Manifesto</h1>
     <h2 class="p-heading--4 u-sv3" style="max-width: 40rem;">Better operators through open community standards</h2>
     <p>Our goal is to improve devsecops with open source operators for widely used software. These shared values ensure high quality code and conversations.</p>
   </div>  


### PR DESCRIPTION
## Done

- Update title for juju.is/model-driven-operations-manifesto

## QA

- Check https://juju-is-265.demos.haus/model-driven-operations-manifesto
- The title should be "The Model Driven Operator Manifesto"


## Issue / Card

Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/1045
