### PR TITLE
Add scroll padding to k8s report

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -240,3 +240,7 @@ h3 {
     text-decoration: none;
   }
 }
+
+html {
+  scroll-padding-top: 80px;
+}


### PR DESCRIPTION
## Done
Fixed hidden headings under fixed header

## QA
- Go to https://juju-is-276.demos.haus/cloud-native-kubernetes-usage-report-2021
- Click the links in the side navigation
- Check that the headings for each section are not hidden under the fixed header

## Issue
Fixes #273