### PR TITLE
Close side nav on mobile when clicking link

### DIFF
--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -6965,9 +6965,19 @@
       document.querySelectorAll(".js-drawer-toggle"
     ));
 
+    var navigationLinks = Array.prototype.slice.call(
+      navigationDrawer.querySelectorAll("a")
+    );
+
     navigationDrawerToggles.forEach(function(toggle) {
       toggle.addEventListener("click", function() {
         navigationDrawer.classList.toggle("is-expanded");
+      });
+    });
+
+    navigationLinks.forEach(function(link) {
+      link.addEventListener("click", function() {
+        navigationDrawer.classList.remove("is-expanded");
       });
     });
   })();


### PR DESCRIPTION
## Done
Close side nav on report page when link is clicked

## QA
- Go to https://juju-is-279.demos.haus/cloud-native-kubernetes-usage-report-2021
- Resize viewport to mobile width
- Open the side navigation
- Click on any of the links
- Check that the navigation closes and that you are taken to the section you clicked on

## Issue
Fixes #280