### PR TITLE
Make survey charts legible on mobile

### DIFF
--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -686,287 +686,287 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">23.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">23.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 23.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>SRE/DevOps Engineer</strong>
-              <span class="p-survey-chart__response-count">275 responses</span>
+              <strong class="u-truncate">SRE/DevOps Engineer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">275 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Infrastructure Architect</strong>
-              <span class="p-survey-chart__response-count">134 responses</span>
+              <strong class="u-truncate">Infrastructure Architect</strong>
+              <span class="p-survey-chart__response-count u-hide--small">134 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">9.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">9.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 9.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Back-end developer</strong>
-              <span class="p-survey-chart__response-count">114 responses</span>
+              <strong class="u-truncate">Back-end developer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">114 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Full-Stack Developer</strong>
-              <span class="p-survey-chart__response-count">101 responses</span>
+              <strong class="u-truncate">Full-Stack Developer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">101 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Academic/Teacher/Student</strong>
-              <span class="p-survey-chart__response-count">64 responses</span>
+              <strong class="u-truncate">Academic/Teacher/Student</strong>
+              <span class="p-survey-chart__response-count u-hide--small">64 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Security Engineer</strong>
-              <span class="p-survey-chart__response-count">53 responses</span>
+              <strong class="u-truncate">Security Engineer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">53 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Software Architect</strong>
-              <span class="p-survey-chart__response-count">48 responses</span>
+              <strong class="u-truncate">Software Architect</strong>
+              <span class="p-survey-chart__response-count u-hide--small">48 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">47 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">47 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Consultant</strong>
-              <span class="p-survey-chart__response-count">40 responses</span>
+              <strong class="u-truncate">Consultant</strong>
+              <span class="p-survey-chart__response-count u-hide--small">40 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>DevOps Management</strong>
-              <span class="p-survey-chart__response-count">39 responses</span>
+              <strong class="u-truncate">DevOps Management</strong>
+              <span class="p-survey-chart__response-count u-hide--small">39 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Engineering Manager</strong>
-              <span class="p-survey-chart__response-count">36 responses</span>
+              <strong class="u-truncate">Engineering Manager</strong>
+              <span class="p-survey-chart__response-count u-hide--small">36 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Front-End/Applications Developer</strong>
-              <span class="p-survey-chart__response-count">34 responses</span>
+              <strong class="u-truncate">Front-End/Applications Developer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">34 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Data Scientist</strong>
-              <span class="p-survey-chart__response-count">33 responses</span>
+              <strong class="u-truncate">Data Scientist</strong>
+              <span class="p-survey-chart__response-count u-hide--small">33 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Mobile Developer</strong>
-              <span class="p-survey-chart__response-count">23 responses</span>
+              <strong class="u-truncate">Mobile Developer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">23 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>CTO</strong>
-              <span class="p-survey-chart__response-count">21 responses</span>
+              <strong class="u-truncate">CTO</strong>
+              <span class="p-survey-chart__response-count u-hide--small">21 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Executive</strong>
-              <span class="p-survey-chart__response-count">16 responses</span>
+              <strong class="u-truncate">Executive</strong>
+              <span class="p-survey-chart__response-count u-hide--small">16 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Developer Advocate</strong>
-              <span class="p-survey-chart__response-count">14 responses</span>
+              <strong class="u-truncate">Developer Advocate</strong>
+              <span class="p-survey-chart__response-count u-hide--small">14 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Database Administrator</strong>
-              <span class="p-survey-chart__response-count">12 responses</span>
+              <strong class="u-truncate">Database Administrator</strong>
+              <span class="p-survey-chart__response-count u-hide--small">12 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Machine Learning Specialist</strong>
-              <span class="p-survey-chart__response-count">12 responses</span>
+              <strong class="u-truncate">Machine Learning Specialist</strong>
+              <span class="p-survey-chart__response-count u-hide--small">12 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Project Manager</strong>
-              <span class="p-survey-chart__response-count">12 responses</span>
+              <strong class="u-truncate">Project Manager</strong>
+              <span class="p-survey-chart__response-count u-hide--small">12 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Product Manager</strong>
-              <span class="p-survey-chart__response-count">10 responses</span>
+              <strong class="u-truncate">Product Manager</strong>
+              <span class="p-survey-chart__response-count u-hide--small">10 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Quality Assurance Engineer</strong>
-              <span class="p-survey-chart__response-count">9 responses</span>
+              <strong class="u-truncate">Quality Assurance Engineer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">9 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Sales representitive</strong>
-              <span class="p-survey-chart__response-count">6 responses</span>
+              <strong class="u-truncate">Sales representitive</strong>
+              <span class="p-survey-chart__response-count u-hide--small">6 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>CIO</strong>
-              <span class="p-survey-chart__response-count">4 responses</span>
+              <strong class="u-truncate">CIO</strong>
+              <span class="p-survey-chart__response-count u-hide--small">4 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Release Management</strong>
-              <span class="p-survey-chart__response-count">3 responses</span>
+              <strong class="u-truncate">Release Management</strong>
+              <span class="p-survey-chart__response-count u-hide--small">3 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Marketing professional</strong>
-              <span class="p-survey-chart__response-count">2 responses</span>
+              <strong class="u-truncate">Marketing professional</strong>
+              <span class="p-survey-chart__response-count u-hide--small">2 responses</span>
             </div>
           </div>
         </div>
@@ -1089,100 +1089,100 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">37.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">37.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 37.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>dog</strong>
-              <span class="p-survey-chart__response-count">428 responses</span>
+              <strong class="u-truncate">dog</strong>
+              <span class="p-survey-chart__response-count u-hide--small">428 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">18.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">18.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 18.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>cat</strong>
-              <span class="p-survey-chart__response-count">213 responses</span>
+              <strong class="u-truncate">cat</strong>
+              <span class="p-survey-chart__response-count u-hide--small">213 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>penguin</strong>
-              <span class="p-survey-chart__response-count">140 responses</span>
+              <strong class="u-truncate">penguin</strong>
+              <span class="p-survey-chart__response-count u-hide--small">140 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">9.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">9.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 9.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>panda</strong>
-              <span class="p-survey-chart__response-count">112 responses</span>
+              <strong class="u-truncate">panda</strong>
+              <span class="p-survey-chart__response-count u-hide--small">112 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>fish</strong>
-              <span class="p-survey-chart__response-count">82 responses</span>
+              <strong class="u-truncate">fish</strong>
+              <span class="p-survey-chart__response-count u-hide--small">82 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>pterodactyl</strong>
-              <span class="p-survey-chart__response-count">68 responses</span>
+              <strong class="u-truncate">pterodactyl</strong>
+              <span class="p-survey-chart__response-count u-hide--small">68 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>bird</strong>
-              <span class="p-survey-chart__response-count">58 responses</span>
+              <strong class="u-truncate">bird</strong>
+              <span class="p-survey-chart__response-count u-hide--small">58 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>racoon</strong>
-              <span class="p-survey-chart__response-count">38 responses</span>
+              <strong class="u-truncate">racoon</strong>
+              <span class="p-survey-chart__response-count u-hide--small">38 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>rodent</strong>
-              <span class="p-survey-chart__response-count">10 responses</span>
+              <strong class="u-truncate">rodent</strong>
+              <span class="p-survey-chart__response-count u-hide--small">10 responses</span>
             </div>
           </div>
         </div>
@@ -1198,91 +1198,91 @@
 
           <div class="p-survey-chart">
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">43.02%</span>
+              <span class="p-survey-chart__percentage u-hide--small">43.02%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 43.02%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>dog</strong>
+                  <strong class="u-truncate">dog</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">16.28%</span>
+              <span class="p-survey-chart__percentage u-hide--small">16.28%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 16.28%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>penguin</strong>
+                  <strong class="u-truncate">penguin</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">12.79%</span>
+              <span class="p-survey-chart__percentage u-hide--small">12.79%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 12.79%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>cat</strong>
+                  <strong class="u-truncate">cat</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">8.14%</span>
+              <span class="p-survey-chart__percentage u-hide--small">8.14%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 8.14%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>pterodactyl</strong>
+                  <strong class="u-truncate">pterodactyl</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">5.81%</span>
+              <span class="p-survey-chart__percentage u-hide--small">5.81%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 5.81%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>fish</strong>
+                  <strong class="u-truncate">fish</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">5.81%</span>
+              <span class="p-survey-chart__percentage u-hide--small">5.81%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 5.81%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>panda</strong>
+                  <strong class="u-truncate">panda</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">4.65%</span>
+              <span class="p-survey-chart__percentage u-hide--small">4.65%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 4.65%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>bird</strong>
+                  <strong class="u-truncate">bird</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">2.33%</span>
+              <span class="p-survey-chart__percentage u-hide--small">2.33%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 2.33%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>racoon</strong>
+                  <strong class="u-truncate">racoon</strong>
                 </div>
               </div>
             </div>
 
             <div class="p-survey-chart__row">
-              <span class="p-survey-chart__percentage">1.16%</span>
+              <span class="p-survey-chart__percentage u-hide--small">1.16%</span>
               <div class="p-survey-chart__bar">
                 <div class="p-survey-chart__result" style="width: 1.16%;"></div>
                 <div class="p-survey-chart__content">
-                  <strong>rodent</strong>
+                  <strong class="u-truncate">rodent</strong>
                 </div>
               </div>
             </div>
@@ -1298,276 +1298,276 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">40.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">40.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 40.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Software/Technology</strong>
-              <span class="p-survey-chart__response-count">468 responses</span>
+              <strong class="u-truncate">Software/Technology</strong>
+              <span class="p-survey-chart__response-count u-hide--small">468 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">9.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">9.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 9.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Financial Services</strong>
-              <span class="p-survey-chart__response-count">108 responses</span>
+              <strong class="u-truncate">Financial Services</strong>
+              <span class="p-survey-chart__response-count u-hide--small">108 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Education</strong>
-              <span class="p-survey-chart__response-count">94 responses</span>
+              <strong class="u-truncate">Education</strong>
+              <span class="p-survey-chart__response-count u-hide--small">94 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Consulting</strong>
-              <span class="p-survey-chart__response-count">83 responses</span>
+              <strong class="u-truncate">Consulting</strong>
+              <span class="p-survey-chart__response-count u-hide--small">83 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Telecommunications</strong>
-              <span class="p-survey-chart__response-count">74 responses</span>
+              <strong class="u-truncate">Telecommunications</strong>
+              <span class="p-survey-chart__response-count u-hide--small">74 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Government</strong>
-              <span class="p-survey-chart__response-count">40 responses</span>
+              <strong class="u-truncate">Government</strong>
+              <span class="p-survey-chart__response-count u-hide--small">40 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Healthcare</strong>
-              <span class="p-survey-chart__response-count">39 responses</span>
+              <strong class="u-truncate">Healthcare</strong>
+              <span class="p-survey-chart__response-count u-hide--small">39 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Professional Services</strong>
-              <span class="p-survey-chart__response-count">31 responses</span>
+              <strong class="u-truncate">Professional Services</strong>
+              <span class="p-survey-chart__response-count u-hide--small">31 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Manufacturing</strong>
-              <span class="p-survey-chart__response-count">22 responses</span>
+              <strong class="u-truncate">Manufacturing</strong>
+              <span class="p-survey-chart__response-count u-hide--small">22 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Consumer</strong>
-              <span class="p-survey-chart__response-count">21 responses</span>
+              <strong class="u-truncate">Consumer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">21 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Scientific or technical services</strong>
-              <span class="p-survey-chart__response-count">21 responses</span>
+              <strong class="u-truncate">Scientific or technical services</strong>
+              <span class="p-survey-chart__response-count u-hide--small">21 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Transportation and warehousing</strong>
-              <span class="p-survey-chart__response-count">21 responses</span>
+              <strong class="u-truncate">Transportation and warehousing</strong>
+              <span class="p-survey-chart__response-count u-hide--small">21 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Engery &amp; Utilities</strong>
-              <span class="p-survey-chart__response-count">20 responses</span>
+              <strong class="u-truncate">Engery &amp; Utilities</strong>
+              <span class="p-survey-chart__response-count u-hide--small">20 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Retail</strong>
-              <span class="p-survey-chart__response-count">19 responses</span>
+              <strong class="u-truncate">Retail</strong>
+              <span class="p-survey-chart__response-count u-hide--small">19 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Media/Analyst</strong>
-              <span class="p-survey-chart__response-count">16 responses</span>
+              <strong class="u-truncate">Media/Analyst</strong>
+              <span class="p-survey-chart__response-count u-hide--small">16 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Arts, Entertainment</strong>
-              <span class="p-survey-chart__response-count">13 responses</span>
+              <strong class="u-truncate">Arts, Entertainment</strong>
+              <span class="p-survey-chart__response-count u-hide--small">13 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Non-profit</strong>
-              <span class="p-survey-chart__response-count">12 responses</span>
+              <strong class="u-truncate">Non-profit</strong>
+              <span class="p-survey-chart__response-count u-hide--small">12 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Military</strong>
-              <span class="p-survey-chart__response-count">7 responses</span>
+              <strong class="u-truncate">Military</strong>
+              <span class="p-survey-chart__response-count u-hide--small">7 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Agriculture</strong>
-              <span class="p-survey-chart__response-count">5 responses</span>
+              <strong class="u-truncate">Agriculture</strong>
+              <span class="p-survey-chart__response-count u-hide--small">5 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Hotel and Food Service</strong>
-              <span class="p-survey-chart__response-count">5 responses</span>
+              <strong class="u-truncate">Hotel and Food Service</strong>
+              <span class="p-survey-chart__response-count u-hide--small">5 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Construction</strong>
-              <span class="p-survey-chart__response-count">4 responses</span>
+              <strong class="u-truncate">Construction</strong>
+              <span class="p-survey-chart__response-count u-hide--small">4 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Legal Services</strong>
-              <span class="p-survey-chart__response-count">4 responses</span>
+              <strong class="u-truncate">Legal Services</strong>
+              <span class="p-survey-chart__response-count u-hide--small">4 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Religious</strong>
-              <span class="p-survey-chart__response-count">2 responses</span>
+              <strong class="u-truncate">Religious</strong>
+              <span class="p-survey-chart__response-count u-hide--small">2 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Real estate, rental, leasing</strong>
-              <span class="p-survey-chart__response-count">1 response</span>
+              <strong class="u-truncate">Real estate, rental, leasing</strong>
+              <span class="p-survey-chart__response-count u-hide--small">1 response</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">26 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">26 responses</span>
             </div>
           </div>
         </div>
@@ -1627,67 +1627,67 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">39.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">39.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 39.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>The one without the camera on</strong>
-              <span class="p-survey-chart__response-count">460 responses</span>
+              <strong class="u-truncate">The one without the camera on</strong>
+              <span class="p-survey-chart__response-count u-hide--small">460 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">18.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">18.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 18.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Zoom is very serious and we need to focus, people!</strong>
-              <span class="p-survey-chart__response-count">215 responses</span>
+              <strong class="u-truncate">Zoom is very serious and we need to focus, people!</strong>
+              <span class="p-survey-chart__response-count u-hide--small">215 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12%;"></div>
             <div class="p-survey-chart__content">
-              <strong>The one who always talks</strong>
-              <span class="p-survey-chart__response-count">139 responses</span>
+              <strong class="u-truncate">The one who always talks</strong>
+              <span class="p-survey-chart__response-count u-hide--small">139 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12%;"></div>
             <div class="p-survey-chart__content">
-              <strong>The one who just woke up</strong>
-              <span class="p-survey-chart__response-count">139 responses</span>
+              <strong class="u-truncate">The one who just woke up</strong>
+              <span class="p-survey-chart__response-count u-hide--small">139 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>The one walking around the house</strong>
-              <span class="p-survey-chart__response-count">132 responses</span>
+              <strong class="u-truncate">The one walking around the house</strong>
+              <span class="p-survey-chart__response-count u-hide--small">132 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>The one doing funny faces</strong>
-              <span class="p-survey-chart__response-count">72 responses</span>
+              <strong class="u-truncate">The one doing funny faces</strong>
+              <span class="p-survey-chart__response-count u-hide--small">72 responses</span>
             </div>
           </div>
         </div>
@@ -1701,45 +1701,45 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">51.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">51.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 51.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Nooo</strong>
-              <span class="p-survey-chart__response-count">599 responses</span>
+              <strong class="u-truncate">Nooo</strong>
+              <span class="p-survey-chart__response-count u-hide--small">599 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">30.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">30.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 30.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>100% yes</strong>
-              <span class="p-survey-chart__response-count">353 responses</span>
+              <strong class="u-truncate">100% yes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">353 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Business on top, PJs on the bottom</strong>
-              <span class="p-survey-chart__response-count">146 responses</span>
+              <strong class="u-truncate">Business on top, PJs on the bottom</strong>
+              <span class="p-survey-chart__response-count u-hide--small">146 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I literally took them off a minute ago</strong>
-              <span class="p-survey-chart__response-count">63 responses</span>
+              <strong class="u-truncate">I literally took them off a minute ago</strong>
+              <span class="p-survey-chart__response-count u-hide--small">63 responses</span>
             </div>
           </div>
         </div>
@@ -1760,100 +1760,100 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">64.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">64.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 64.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Improved maintenance, monitoring, and automation</strong>
-              <span class="p-survey-chart__response-count">747 responses</span>
+              <strong class="u-truncate">Improved maintenance, monitoring, and automation</strong>
+              <span class="p-survey-chart__response-count u-hide--small">747 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">46.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">46.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 46.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Modernizing infrastructure</strong>
-              <span class="p-survey-chart__response-count">536 responses</span>
+              <strong class="u-truncate">Modernizing infrastructure</strong>
+              <span class="p-survey-chart__response-count u-hide--small">536 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">26.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">26.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 26.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Faster time to market</strong>
-              <span class="p-survey-chart__response-count">306 responses</span>
+              <strong class="u-truncate">Faster time to market</strong>
+              <span class="p-survey-chart__response-count u-hide--small">306 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Lower time to market</strong>
-              <span class="p-survey-chart__response-count">194 responses</span>
+              <strong class="u-truncate">Lower time to market</strong>
+              <span class="p-survey-chart__response-count u-hide--small">194 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Removing vendor dependencies</strong>
-              <span class="p-survey-chart__response-count">148 responses</span>
+              <strong class="u-truncate">Removing vendor dependencies</strong>
+              <span class="p-survey-chart__response-count u-hide--small">148 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Global reach</strong>
-              <span class="p-survey-chart__response-count">144 responses</span>
+              <strong class="u-truncate">Global reach</strong>
+              <span class="p-survey-chart__response-count u-hide--small">144 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">9.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">9.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 9.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Agility around traffic spikes</strong>
-              <span class="p-survey-chart__response-count">106 responses</span>
+              <strong class="u-truncate">Agility around traffic spikes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">106 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Ensure portability</strong>
-              <span class="p-survey-chart__response-count">103 responses</span>
+              <strong class="u-truncate">Ensure portability</strong>
+              <span class="p-survey-chart__response-count u-hide--small">103 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">28 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">28 responses</span>
             </div>
           </div>
         </div>
@@ -2012,67 +2012,67 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">75.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">75.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 75.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A combination of at least one private cloud and one public cloud</strong>
-              <span class="p-survey-chart__response-count">877 responses</span>
+              <strong class="u-truncate">A combination of at least one private cloud and one public cloud</strong>
+              <span class="p-survey-chart__response-count u-hide--small">877 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>You put your left foot in, you take your left foot out, you put your left foot in, and you shake it all about</strong>
-              <span class="p-survey-chart__response-count">89 responses</span>
+              <strong class="u-truncate">You put your left foot in, you take your left foot out, you put your left foot in, and you shake it all about</strong>
+              <span class="p-survey-chart__response-count u-hide--small">89 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A combination of at least two public clouds and a private cloud</strong>
-              <span class="p-survey-chart__response-count">86 responses</span>
+              <strong class="u-truncate">A combination of at least two public clouds and a private cloud</strong>
+              <span class="p-survey-chart__response-count u-hide--small">86 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A combination of at least two private clouds</strong>
-              <span class="p-survey-chart__response-count">40 responses</span>
+              <strong class="u-truncate">A combination of at least two private clouds</strong>
+              <span class="p-survey-chart__response-count u-hide--small">40 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A combination of at least two public clouds</strong>
-              <span class="p-survey-chart__response-count">40 responses</span>
+              <strong class="u-truncate">A combination of at least two public clouds</strong>
+              <span class="p-survey-chart__response-count u-hide--small">40 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">23 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">23 responses</span>
             </div>
           </div>
         </div>
@@ -2112,122 +2112,122 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>We don&rsquo;t use hybrid or multi-cloud</strong>
-              <span class="p-survey-chart__response-count">256 responses</span>
+              <strong class="u-truncate">We don&rsquo;t use hybrid or multi-cloud</strong>
+              <span class="p-survey-chart__response-count u-hide--small">256 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Accelerate development, automate DevOps</strong>
-              <span class="p-survey-chart__response-count">239 responses</span>
+              <strong class="u-truncate">Accelerate development, automate DevOps</strong>
+              <span class="p-survey-chart__response-count u-hide--small">239 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Expand cloud backup options to cut costs</strong>
-              <span class="p-survey-chart__response-count">153 responses</span>
+              <strong class="u-truncate">Expand cloud backup options to cut costs</strong>
+              <span class="p-survey-chart__response-count u-hide--small">153 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Disaster recovery</strong>
-              <span class="p-survey-chart__response-count">145 responses</span>
+              <strong class="u-truncate">Disaster recovery</strong>
+              <span class="p-survey-chart__response-count u-hide--small">145 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Cluster mission-critical databases</strong>
-              <span class="p-survey-chart__response-count">71 responses</span>
+              <strong class="u-truncate">Cluster mission-critical databases</strong>
+              <span class="p-survey-chart__response-count u-hide--small">71 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Move an application</strong>
-              <span class="p-survey-chart__response-count">64 responses</span>
+              <strong class="u-truncate">Move an application</strong>
+              <span class="p-survey-chart__response-count u-hide--small">64 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Cloud bursting</strong>
-              <span class="p-survey-chart__response-count">61 responses</span>
+              <strong class="u-truncate">Cloud bursting</strong>
+              <span class="p-survey-chart__response-count u-hide--small">61 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Switch between public cloud providers in a flash</strong>
-              <span class="p-survey-chart__response-count">48 responses</span>
+              <strong class="u-truncate">Switch between public cloud providers in a flash</strong>
+              <span class="p-survey-chart__response-count u-hide--small">48 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>On and off-ramp data</strong>
-              <span class="p-survey-chart__response-count">46 responses</span>
+              <strong class="u-truncate">On and off-ramp data</strong>
+              <span class="p-survey-chart__response-count u-hide--small">46 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Monitor and predict usage costs</strong>
-              <span class="p-survey-chart__response-count">28 responses</span>
+              <strong class="u-truncate">Monitor and predict usage costs</strong>
+              <span class="p-survey-chart__response-count u-hide--small">28 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">43 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">43 responses</span>
             </div>
           </div>
         </div>
@@ -2334,122 +2334,122 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>6-20</strong>
-              <span class="p-survey-chart__response-count">157 responses</span>
+              <strong class="u-truncate">6-20</strong>
+              <span class="p-survey-chart__response-count u-hide--small">157 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1.5</strong>
-              <span class="p-survey-chart__response-count">152 responses</span>
+              <strong class="u-truncate">1.5</strong>
+              <span class="p-survey-chart__response-count u-hide--small">152 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>51-100</strong>
-              <span class="p-survey-chart__response-count">147 responses</span>
+              <strong class="u-truncate">51-100</strong>
+              <span class="p-survey-chart__response-count u-hide--small">147 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>N/A or don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">128 responses</span>
+              <strong class="u-truncate">N/A or don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">128 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>21-50</strong>
-              <span class="p-survey-chart__response-count">120 responses</span>
+              <strong class="u-truncate">21-50</strong>
+              <span class="p-survey-chart__response-count u-hide--small">120 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">9.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">9.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 9.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>201-500</strong>
-              <span class="p-survey-chart__response-count">107 responses</span>
+              <strong class="u-truncate">201-500</strong>
+              <span class="p-survey-chart__response-count u-hide--small">107 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>99</strong>
-              <span class="p-survey-chart__response-count">157 responses</span>
+              <strong class="u-truncate">99</strong>
+              <span class="p-survey-chart__response-count u-hide--small">157 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>501-1000</strong>
-              <span class="p-survey-chart__response-count">80 responses</span>
+              <strong class="u-truncate">501-1000</strong>
+              <span class="p-survey-chart__response-count u-hide--small">80 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>5000+</strong>
-              <span class="p-survey-chart__response-count">76 responses</span>
+              <strong class="u-truncate">5000+</strong>
+              <span class="p-survey-chart__response-count u-hide--small">76 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>2001-5000</strong>
-              <span class="p-survey-chart__response-count">47 responses</span>
+              <strong class="u-truncate">2001-5000</strong>
+              <span class="p-survey-chart__response-count u-hide--small">47 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1001-2000</strong>
-              <span class="p-survey-chart__response-count">45 responses</span>
+              <strong class="u-truncate">1001-2000</strong>
+              <span class="p-survey-chart__response-count u-hide--small">45 responses</span>
             </div>
           </div>
         </div>
@@ -2460,89 +2460,89 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">30.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">30.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 30.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>2.5</strong>
-              <span class="p-survey-chart__response-count">348 responses</span>
+              <strong class="u-truncate">2.5</strong>
+              <span class="p-survey-chart__response-count u-hide--small">348 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15%;"></div>
             <div class="p-survey-chart__content">
-              <strong>None</strong>
-              <span class="p-survey-chart__response-count">173 responses</span>
+              <strong class="u-truncate">None</strong>
+              <span class="p-survey-chart__response-count u-hide--small">173 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">157 responses</span>
+              <strong class="u-truncate">Don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">157 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>6-10</strong>
-              <span class="p-survey-chart__response-count">138 responses</span>
+              <strong class="u-truncate">6-10</strong>
+              <span class="p-survey-chart__response-count u-hide--small">138 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1</strong>
-              <span class="p-survey-chart__response-count">122 responses</span>
+              <strong class="u-truncate">1</strong>
+              <span class="p-survey-chart__response-count u-hide--small">122 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>11-20</strong>
-              <span class="p-survey-chart__response-count">97 responses</span>
+              <strong class="u-truncate">11-20</strong>
+              <span class="p-survey-chart__response-count u-hide--small">97 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>50+</strong>
-              <span class="p-survey-chart__response-count">72 responses</span>
+              <strong class="u-truncate">50+</strong>
+              <span class="p-survey-chart__response-count u-hide--small">72 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>21-50</strong>
-              <span class="p-survey-chart__response-count">49 responses</span>
+              <strong class="u-truncate">21-50</strong>
+              <span class="p-survey-chart__response-count u-hide--small">49 responses</span>
             </div>
           </div>
         </div>
@@ -2704,78 +2704,78 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">34.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">34.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 34.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Huh? (I honestly don&rsquo;t know)</strong>
-              <span class="p-survey-chart__response-count">401 responses</span>
+              <strong class="u-truncate">Huh? (I honestly don&rsquo;t know)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">401 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">26.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">26.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 26.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>It&rsquo;s the base infrastructure that we build everything upon</strong>
-              <span class="p-survey-chart__response-count">308 responses</span>
+              <strong class="u-truncate">It&rsquo;s the base infrastructure that we build everything upon</strong>
+              <span class="p-survey-chart__response-count u-hide--small">308 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>VMs/containers</strong>
-              <span class="p-survey-chart__response-count">138 responses</span>
+              <strong class="u-truncate">VMs/containers</strong>
+              <span class="p-survey-chart__response-count u-hide--small">138 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Abstraction layer</strong>
-              <span class="p-survey-chart__response-count">118 responses</span>
+              <strong class="u-truncate">Abstraction layer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">118 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Bare metal</strong>
-              <span class="p-survey-chart__response-count">89 responses</span>
+              <strong class="u-truncate">Bare metal</strong>
+              <span class="p-survey-chart__response-count u-hide--small">89 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Physical layer</strong>
-              <span class="p-survey-chart__response-count">70 responses</span>
+              <strong class="u-truncate">Physical layer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">70 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Earthly material</strong>
-              <span class="p-survey-chart__response-count">31 responses</span>
+              <strong class="u-truncate">Earthly material</strong>
+              <span class="p-survey-chart__response-count u-hide--small">31 responses</span>
             </div>
           </div>
         </div>
@@ -2834,23 +2834,23 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">45.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">45.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 45.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes</strong>
-              <span class="p-survey-chart__response-count">516 responses</span>
+              <strong class="u-truncate">Yes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">516 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">54.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">54.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 54.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>No</strong>
-              <span class="p-survey-chart__response-count">627 responses</span>
+              <strong class="u-truncate">No</strong>
+              <span class="p-survey-chart__response-count u-hide--small">627 responses</span>
             </div>
           </div>
         </div>
@@ -2867,67 +2867,67 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">29.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">29.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 29.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>On a mix of bare metal, VMs and Kubernetes</strong>
-              <span class="p-survey-chart__response-count">346 responses</span>
+              <strong class="u-truncate">On a mix of bare metal, VMs and Kubernetes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">346 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>All our applications are on Kubernetes</strong>
-              <span class="p-survey-chart__response-count">182 responses</span>
+              <strong class="u-truncate">All our applications are on Kubernetes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">182 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Mostly on VMs, planning a full migration to Kubernetes</strong>
-              <span class="p-survey-chart__response-count">177 responses</span>
+              <strong class="u-truncate">Mostly on VMs, planning a full migration to Kubernetes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">177 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>On VMs, evaluating Kubernetes for development</strong>
-              <span class="p-survey-chart__response-count">152 responses</span>
+              <strong class="u-truncate">On VMs, evaluating Kubernetes for development</strong>
+              <span class="p-survey-chart__response-count u-hide--small">152 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">67 responses</span>
+              <strong class="u-truncate">Don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">67 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">42 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">42 responses</span>
             </div>
           </div>
         </div>
@@ -3002,89 +3002,89 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">36.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">36.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 36.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Deploying or managing Kubernetes-as-a-service</strong>
-              <span class="p-survey-chart__response-count">420 responses</span>
+              <strong class="u-truncate">Deploying or managing Kubernetes-as-a-service</strong>
+              <span class="p-survey-chart__response-count u-hide--small">420 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">34.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">34.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 34%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Re-architecting proprietary solution into microservices</strong>
-              <span class="p-survey-chart__response-count">393 responses</span>
+              <strong class="u-truncate">Re-architecting proprietary solution into microservices</strong>
+              <span class="p-survey-chart__response-count u-hide--small">393 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">26.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">26.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 26.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Moving to an open-source solution</strong>
-              <span class="p-survey-chart__response-count">309 responses</span>
+              <strong class="u-truncate">Moving to an open-source solution</strong>
+              <span class="p-survey-chart__response-count u-hide--small">309 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">25.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">25.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 25.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Orchestrating workloads across a multi-cloud setting</strong>
-              <span class="p-survey-chart__response-count">297 responses</span>
+              <strong class="u-truncate">Orchestrating workloads across a multi-cloud setting</strong>
+              <span class="p-survey-chart__response-count u-hide--small">297 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">25.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">25.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 25.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Managing or enabling a hybrid-cloud setup</strong>
-              <span class="p-survey-chart__response-count">284 responses</span>
+              <strong class="u-truncate">Managing or enabling a hybrid-cloud setup</strong>
+              <span class="p-survey-chart__response-count u-hide--small">284 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">24.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">24.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 24.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Using best-of breed cloud-native tools</strong>
-              <span class="p-survey-chart__response-count">284 responses</span>
+              <strong class="u-truncate">Using best-of breed cloud-native tools</strong>
+              <span class="p-survey-chart__response-count u-hide--small">284 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Deploying business solutions in different geographies</strong>
-              <span class="p-survey-chart__response-count">231 responses</span>
+              <strong class="u-truncate">Deploying business solutions in different geographies</strong>
+              <span class="p-survey-chart__response-count u-hide--small">231 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>None of the above</strong>
-              <span class="p-survey-chart__response-count">157 responses</span>
+              <strong class="u-truncate">None of the above</strong>
+              <span class="p-survey-chart__response-count u-hide--small">157 responses</span>
             </div>
           </div>
         </div>
@@ -3122,166 +3122,166 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">54.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">54.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 54.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Lack of in-house skills/limited manpower</strong>
-              <span class="p-survey-chart__response-count">628 responses</span>
+              <strong class="u-truncate">Lack of in-house skills/limited manpower</strong>
+              <span class="p-survey-chart__response-count u-hide--small">628 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">37.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">37.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 37.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Company IT structure</strong>
-              <span class="p-survey-chart__response-count">430 responses</span>
+              <strong class="u-truncate">Company IT structure</strong>
+              <span class="p-survey-chart__response-count u-hide--small">430 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">32.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">32.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 32.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Incompatibility with legacy systems</strong>
-              <span class="p-survey-chart__response-count">376 responses</span>
+              <strong class="u-truncate">Incompatibility with legacy systems</strong>
+              <span class="p-survey-chart__response-count u-hide--small">376 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">29.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">29.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 29.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Difficulty training users</strong>
-              <span class="p-survey-chart__response-count">343 responses</span>
+              <strong class="u-truncate">Difficulty training users</strong>
+              <span class="p-survey-chart__response-count u-hide--small">343 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">24.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">24.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 24.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Security and compliance concerns not addressed adequately</strong>
-              <span class="p-survey-chart__response-count">285 responses</span>
+              <strong class="u-truncate">Security and compliance concerns not addressed adequately</strong>
+              <span class="p-survey-chart__response-count u-hide--small">285 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">19.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">19.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 19%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Integrating cloud-native applications together</strong>
-              <span class="p-survey-chart__response-count">219 responses</span>
+              <strong class="u-truncate">Integrating cloud-native applications together</strong>
+              <span class="p-survey-chart__response-count u-hide--small">219 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">18.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">18.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 18.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Observability/monitoring requirements not addressed adequately</strong>
-              <span class="p-survey-chart__response-count">213 responses</span>
+              <strong class="u-truncate">Observability/monitoring requirements not addressed adequately</strong>
+              <span class="p-survey-chart__response-count u-hide--small">213 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">18.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">18.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 18%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Networking requirements not addressed adequately</strong>
-              <span class="p-survey-chart__response-count">207 responses</span>
+              <strong class="u-truncate">Networking requirements not addressed adequately</strong>
+              <span class="p-survey-chart__response-count u-hide--small">207 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Cost overruns</strong>
-              <span class="p-survey-chart__response-count">193 responses</span>
+              <strong class="u-truncate">Cost overruns</strong>
+              <span class="p-survey-chart__response-count u-hide--small">193 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Velocity of evolution of the k8s platform</strong>
-              <span class="p-survey-chart__response-count">192 responses</span>
+              <strong class="u-truncate">Velocity of evolution of the k8s platform</strong>
+              <span class="p-survey-chart__response-count u-hide--small">192 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Storage/Data requirements not addressed adequately</strong>
-              <span class="p-survey-chart__response-count">182 responses</span>
+              <strong class="u-truncate">Storage/Data requirements not addressed adequately</strong>
+              <span class="p-survey-chart__response-count u-hide--small">182 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">14.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">14.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 14.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Inefficient day to day operations</strong>
-              <span class="p-survey-chart__response-count">163 responses</span>
+              <strong class="u-truncate">Inefficient day to day operations</strong>
+              <span class="p-survey-chart__response-count u-hide--small">163 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">14.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">14.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 14%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Poor or limited support from platform providers or partners</strong>
-              <span class="p-survey-chart__response-count">141 responses</span>
+              <strong class="u-truncate">Poor or limited support from platform providers or partners</strong>
+              <span class="p-survey-chart__response-count u-hide--small">141 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Cloud platforms don&rsquo;t meet needs/expectations</strong>
-              <span class="p-survey-chart__response-count">127 responses</span>
+              <strong class="u-truncate">Cloud platforms don&rsquo;t meet needs/expectations</strong>
+              <span class="p-survey-chart__response-count u-hide--small">127 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Lack of flexibility when it comes to address workload</strong>
-              <span class="p-survey-chart__response-count">103 responses</span>
+              <strong class="u-truncate">Lack of flexibility when it comes to address workload</strong>
+              <span class="p-survey-chart__response-count u-hide--small">103 responses</span>
             </div>
           </div>
         </div>
@@ -3369,221 +3369,221 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">49.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">49.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 49.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>AWS</strong>
-              <span class="p-survey-chart__response-count">575 responses</span>
+              <strong class="u-truncate">AWS</strong>
+              <span class="p-survey-chart__response-count u-hide--small">575 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">34.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">34.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 34.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Azure</strong>
-              <span class="p-survey-chart__response-count">398 responses</span>
+              <strong class="u-truncate">Azure</strong>
+              <span class="p-survey-chart__response-count u-hide--small">398 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">24.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">24.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 24.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>GCP</strong>
-              <span class="p-survey-chart__response-count">284 responses</span>
+              <strong class="u-truncate">GCP</strong>
+              <span class="p-survey-chart__response-count u-hide--small">284 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">24.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">24.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 24.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>VMware</strong>
-              <span class="p-survey-chart__response-count">284 responses</span>
+              <strong class="u-truncate">VMware</strong>
+              <span class="p-survey-chart__response-count u-hide--small">284 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">23.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">23.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 23.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Bare metal</strong>
-              <span class="p-survey-chart__response-count">276 responses</span>
+              <strong class="u-truncate">Bare metal</strong>
+              <span class="p-survey-chart__response-count u-hide--small">276 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>OpenStack</strong>
-              <span class="p-survey-chart__response-count">181 responses</span>
+              <strong class="u-truncate">OpenStack</strong>
+              <span class="p-survey-chart__response-count u-hide--small">181 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Private Cloud</strong>
-              <span class="p-survey-chart__response-count">157 responses</span>
+              <strong class="u-truncate">Private Cloud</strong>
+              <span class="p-survey-chart__response-count u-hide--small">157 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>KVM</strong>
-              <span class="p-survey-chart__response-count">122 responses</span>
+              <strong class="u-truncate">KVM</strong>
+              <span class="p-survey-chart__response-count u-hide--small">122 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Digital Ocean</strong>
-              <span class="p-survey-chart__response-count">90 responses</span>
+              <strong class="u-truncate">Digital Ocean</strong>
+              <span class="p-survey-chart__response-count u-hide--small">90 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">89 responses</span>
+              <strong class="u-truncate">Don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">89 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>IBM Cloud</strong>
-              <span class="p-survey-chart__response-count">79 responses</span>
+              <strong class="u-truncate">IBM Cloud</strong>
+              <span class="p-survey-chart__response-count u-hide--small">79 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Oracle Cloud</strong>
-              <span class="p-survey-chart__response-count">50 responses</span>
+              <strong class="u-truncate">Oracle Cloud</strong>
+              <span class="p-survey-chart__response-count u-hide--small">50 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Alibaba Cloud</strong>
-              <span class="p-survey-chart__response-count">37 responses</span>
+              <strong class="u-truncate">Alibaba Cloud</strong>
+              <span class="p-survey-chart__response-count u-hide--small">37 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Nutanix</strong>
-              <span class="p-survey-chart__response-count">35 responses</span>
+              <strong class="u-truncate">Nutanix</strong>
+              <span class="p-survey-chart__response-count u-hide--small">35 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>SAP Cloud Platform</strong>
-              <span class="p-survey-chart__response-count">22 responses</span>
+              <strong class="u-truncate">SAP Cloud Platform</strong>
+              <span class="p-survey-chart__response-count u-hide--small">22 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Vultr</strong>
-              <span class="p-survey-chart__response-count">21 responses</span>
+              <strong class="u-truncate">Vultr</strong>
+              <span class="p-survey-chart__response-count u-hide--small">21 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">1.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">1.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 1.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Packet</strong>
-              <span class="p-survey-chart__response-count">13 responses</span>
+              <strong class="u-truncate">Packet</strong>
+              <span class="p-survey-chart__response-count u-hide--small">13 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Talos</strong>
-              <span class="p-survey-chart__response-count">9 responses</span>
+              <strong class="u-truncate">Talos</strong>
+              <span class="p-survey-chart__response-count u-hide--small">9 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Giant Swarm</strong>
-              <span class="p-survey-chart__response-count">5 responses</span>
+              <strong class="u-truncate">Giant Swarm</strong>
+              <span class="p-survey-chart__response-count u-hide--small">5 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">37 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">37 responses</span>
             </div>
           </div>
         </div>
@@ -3619,78 +3619,78 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">26.06%</span>
+          <span class="p-survey-chart__percentage u-hide--small">26.06%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 26.06%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Newer than 1.10 but older than 1.17</strong>
-              <span class="p-survey-chart__response-count">255 responses</span>
+              <strong class="u-truncate">Newer than 1.10 but older than 1.17</strong>
+              <span class="p-survey-chart__response-count u-hide--small">255 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">18.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">18.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 18.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1.18</strong>
-              <span class="p-survey-chart__response-count">184 responses</span>
+              <strong class="u-truncate">1.18</strong>
+              <span class="p-survey-chart__response-count u-hide--small">184 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1.17</strong>
-              <span class="p-survey-chart__response-count">167 responses</span>
+              <strong class="u-truncate">1.17</strong>
+              <span class="p-survey-chart__response-count u-hide--small">167 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1.19</strong>
-              <span class="p-survey-chart__response-count">136 responses</span>
+              <strong class="u-truncate">1.19</strong>
+              <span class="p-survey-chart__response-count u-hide--small">136 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I say 1.21 because I want to look cool, but it&rsquo;s really 1.20</strong>
-              <span class="p-survey-chart__response-count">110 responses</span>
+              <strong class="u-truncate">I say 1.21 because I want to look cool, but it&rsquo;s really 1.20</strong>
+              <span class="p-survey-chart__response-count u-hide--small">110 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1.20</strong>
-              <span class="p-survey-chart__response-count">70 responses</span>
+              <strong class="u-truncate">1.20</strong>
+              <span class="p-survey-chart__response-count u-hide--small">70 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Older than 1.0 (we don&rsquo;t judge, old timer)</strong>
-              <span class="p-survey-chart__response-count">58 responses</span>
+              <strong class="u-truncate">Older than 1.0 (we don&rsquo;t judge, old timer)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">58 responses</span>
             </div>
           </div>
         </div>
@@ -3795,122 +3795,122 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">32.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">32.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 32.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Minikube</strong>
-              <span class="p-survey-chart__response-count">371 responses</span>
+              <strong class="u-truncate">Minikube</strong>
+              <span class="p-survey-chart__response-count u-hide--small">371 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">31.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">31.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 31.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Docker Kubernetes</strong>
-              <span class="p-survey-chart__response-count">365 responses</span>
+              <strong class="u-truncate">Docker Kubernetes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">365 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">25.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">25.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 25.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>MicroK8s</strong>
-              <span class="p-survey-chart__response-count">294 responses</span>
+              <strong class="u-truncate">MicroK8s</strong>
+              <span class="p-survey-chart__response-count u-hide--small">294 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">23.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">23.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 23.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>On-prem Kubernetes installation</strong>
-              <span class="p-survey-chart__response-count">274 responses</span>
+              <strong class="u-truncate">On-prem Kubernetes installation</strong>
+              <span class="p-survey-chart__response-count u-hide--small">274 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Cloud provider managed Kubernetes</strong>
-              <span class="p-survey-chart__response-count">256 responses</span>
+              <strong class="u-truncate">Cloud provider managed Kubernetes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">256 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>k3s</strong>
-              <span class="p-survey-chart__response-count">238 responses</span>
+              <strong class="u-truncate">k3s</strong>
+              <span class="p-survey-chart__response-count u-hide--small">238 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17%;"></div>
             <div class="p-survey-chart__content">
-              <strong>kind (Kubernetes in Docker)</strong>
-              <span class="p-survey-chart__response-count">196 responses</span>
+              <strong class="u-truncate">kind (Kubernetes in Docker)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">196 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I don&rsquo;t use Kubernetes during local development (e.g. use Docker Compose)</strong>
-              <span class="p-survey-chart__response-count">130 responses</span>
+              <strong class="u-truncate">I don&rsquo;t use Kubernetes during local development (e.g. use Docker Compose)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">130 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">129 responses</span>
+              <strong class="u-truncate">Don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">129 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I don&rsquo;t run containers in local development</strong>
-              <span class="p-survey-chart__response-count">68 responses</span>
+              <strong class="u-truncate">I don&rsquo;t run containers in local development</strong>
+              <span class="p-survey-chart__response-count u-hide--small">68 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">10 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">10 responses</span>
             </div>
           </div>
         </div>
@@ -3986,8 +3986,8 @@
           <div class="p-survey-chart__bar" style="height: 72px;">
             <div class="p-survey-chart__result" style="width: 51.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>51.5%</strong>
-              <span class="p-survey-chart__response-count">584 responses</span>
+              <strong class="u-truncate">51.5%</strong>
+              <span class="p-survey-chart__response-count u-hide--small">584 responses</span>
             </div>
           </div>
         </div>
@@ -4010,8 +4010,8 @@
           <div class="p-survey-chart__bar" style="height: 72px;">
             <div class="p-survey-chart__result" style="width: 48.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>48.5%</strong>
-              <span class="p-survey-chart__response-count">550 responses</span>
+              <strong class="u-truncate">48.5%</strong>
+              <span class="p-survey-chart__response-count u-hide--small">550 responses</span>
             </div>
           </div>
         </div>
@@ -4033,52 +4033,52 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">75.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">75.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 75.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>😊</strong>
-              <span class="p-survey-chart__response-count">863 responses</span>
+              <strong class="u-truncate">😊</strong>
+              <span class="p-survey-chart__response-count u-hide--small">863 responses</span>
             </div>
           </div>
         </div>
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>-</strong>
-              <span class="p-survey-chart__response-count">136 responses</span>
+              <strong class="u-truncate">-</strong>
+              <span class="p-survey-chart__response-count u-hide--small">136 responses</span>
             </div>
           </div>
         </div>
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>-</strong>
-              <span class="p-survey-chart__response-count">61 responses</span>
+              <strong class="u-truncate">-</strong>
+              <span class="p-survey-chart__response-count u-hide--small">61 responses</span>
             </div>
           </div>
         </div>
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>-</strong>
-              <span class="p-survey-chart__response-count">42 responses</span>
+              <strong class="u-truncate">-</strong>
+              <span class="p-survey-chart__response-count u-hide--small">42 responses</span>
             </div>
           </div>
         </div>
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>-</strong>
-              <span class="p-survey-chart__response-count">40 responses</span>
+              <strong class="u-truncate">-</strong>
+              <span class="p-survey-chart__response-count u-hide--small">40 responses</span>
             </div>
           </div>
         </div>
@@ -4114,67 +4114,67 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">37.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">37.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 37.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>0</strong>
-              <span class="p-survey-chart__response-count">432 responses</span>
+              <strong class="u-truncate">0</strong>
+              <span class="p-survey-chart__response-count u-hide--small">432 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">31.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">31.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 31.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1-10</strong>
-              <span class="p-survey-chart__response-count">355 responses</span>
+              <strong class="u-truncate">1-10</strong>
+              <span class="p-survey-chart__response-count u-hide--small">355 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>11-100</strong>
-              <span class="p-survey-chart__response-count">233 responses</span>
+              <strong class="u-truncate">11-100</strong>
+              <span class="p-survey-chart__response-count u-hide--small">233 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>101-500</strong>
-              <span class="p-survey-chart__response-count">79 responses</span>
+              <strong class="u-truncate">101-500</strong>
+              <span class="p-survey-chart__response-count u-hide--small">79 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>1001-10000</strong>
-              <span class="p-survey-chart__response-count">10 responses</span>
+              <strong class="u-truncate">1001-10000</strong>
+              <span class="p-survey-chart__response-count u-hide--small">10 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>10001-1000000</strong>
-              <span class="p-survey-chart__response-count">8 responses</span>
+              <strong class="u-truncate">10001-1000000</strong>
+              <span class="p-survey-chart__response-count u-hide--small">8 responses</span>
             </div>
           </div>
         </div>
@@ -4279,78 +4279,78 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">27.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">27.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 27.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Helm</strong>
-              <span class="p-survey-chart__response-count">316 responses</span>
+              <strong class="u-truncate">Helm</strong>
+              <span class="p-survey-chart__response-count u-hide--small">316 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">23.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">23.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 23%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Scripts (Bash, Python, etc.)</strong>
-              <span class="p-survey-chart__response-count">262 responses</span>
+              <strong class="u-truncate">Scripts (Bash, Python, etc.)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">262 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Configuration Management tools (Ansible, Puppet, Chef, etc)</strong>
-              <span class="p-survey-chart__response-count">198 responses</span>
+              <strong class="u-truncate">Configuration Management tools (Ansible, Puppet, Chef, etc)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">198 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>We prefer a managed Kubernetes offering</strong>
-              <span class="p-survey-chart__response-count">117 responses</span>
+              <strong class="u-truncate">We prefer a managed Kubernetes offering</strong>
+              <span class="p-survey-chart__response-count u-hide--small">117 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Operators: KUDO, K8s Operators, Charmed Operators</strong>
-              <span class="p-survey-chart__response-count">116 responses</span>
+              <strong class="u-truncate">Operators: KUDO, K8s Operators, Charmed Operators</strong>
+              <span class="p-survey-chart__response-count u-hide--small">116 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Kustomize</strong>
-              <span class="p-survey-chart__response-count">82 responses</span>
+              <strong class="u-truncate">Kustomize</strong>
+              <span class="p-survey-chart__response-count u-hide--small">82 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">48 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">48 responses</span>
             </div>
           </div>
         </div>
@@ -4409,45 +4409,45 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">42.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">42.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 42.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">493 responses</span>
+              <strong class="u-truncate">I don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">493 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">28.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">28.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 28.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Operators</strong>
-              <span class="p-survey-chart__response-count">326 responses</span>
+              <strong class="u-truncate">Operators</strong>
+              <span class="p-survey-chart__response-count u-hide--small">326 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">14.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">14.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 14.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>More helm charts</strong>
-              <span class="p-survey-chart__response-count">162 responses</span>
+              <strong class="u-truncate">More helm charts</strong>
+              <span class="p-survey-chart__response-count u-hide--small">162 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">14.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">14.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 14%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Kustomize</strong>
-              <span class="p-survey-chart__response-count">160 responses</span>
+              <strong class="u-truncate">Kustomize</strong>
+              <span class="p-survey-chart__response-count u-hide--small">160 responses</span>
             </div>
           </div>
         </div>
@@ -4534,45 +4534,45 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">38.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">38.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 38.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes, sometimes</strong>
-              <span class="p-survey-chart__response-count">444 responses</span>
+              <strong class="u-truncate">Yes, sometimes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">444 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">34.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">34.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 34.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I&rsquo;ve got fifty cents over here, what can you do for me?</strong>
-              <span class="p-survey-chart__response-count">397 responses</span>
+              <strong class="u-truncate">I&rsquo;ve got fifty cents over here, what can you do for me?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">397 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes, often</strong>
-              <span class="p-survey-chart__response-count">190 responses</span>
+              <strong class="u-truncate">Yes, often</strong>
+              <span class="p-survey-chart__response-count u-hide--small">190 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">9.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">9.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 9.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes, bags of gold</strong>
-              <span class="p-survey-chart__response-count">113 responses</span>
+              <strong class="u-truncate">Yes, bags of gold</strong>
+              <span class="p-survey-chart__response-count u-hide--small">113 responses</span>
             </div>
           </div>
         </div>
@@ -4622,30 +4622,30 @@
         </div>
       </div>
 
-      <h3 id="does-your-team-use-community-provided-templates-playbooks-scripts-packages">26. Does your team use community-provided templates/playbooks/scripts/packages?</h3>
+      <h3 id="does-your-team-use-community-provided-templates-playbooks-scripts-packages">26. Does your team use community-provided templates / playbooks /scripts / packages?</h3>
 
       <h4>Does your team use community-provided templates/playbooks/scripts/packages?</h4>
       <p>1141 out of 1166 people answered this question</p>
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">70.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">70.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 70.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes</strong>
-              <span class="p-survey-chart__response-count">800 responses</span>
+              <strong class="u-truncate">Yes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">800 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">29.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">29.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 29.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>No, we build everything ourselves</strong>
-              <span class="p-survey-chart__response-count">341 responses</span>
+              <strong class="u-truncate">No, we build everything ourselves</strong>
+              <span class="p-survey-chart__response-count u-hide--small">341 responses</span>
             </div>
           </div>
         </div>
@@ -4660,34 +4660,34 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">44.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">44.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 44%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Depends who I&rsquo;m talking to</strong>
-              <span class="p-survey-chart__response-count">501 responses</span>
+              <strong class="u-truncate">Depends who I&rsquo;m talking to</strong>
+              <span class="p-survey-chart__response-count u-hide--small">501 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">30.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">30.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 30.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>False</strong>
-              <span class="p-survey-chart__response-count">343 responses</span>
+              <strong class="u-truncate">False</strong>
+              <span class="p-survey-chart__response-count u-hide--small">343 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">25.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">25.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 25.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>True</strong>
-              <span class="p-survey-chart__response-count">294 responses</span>
+              <strong class="u-truncate">True</strong>
+              <span class="p-survey-chart__response-count u-hide--small">294 responses</span>
             </div>
           </div>
         </div>
@@ -4746,67 +4746,67 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">37.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">37.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 37.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>DevOps</strong>
-              <span class="p-survey-chart__response-count">428 responses</span>
+              <strong class="u-truncate">DevOps</strong>
+              <span class="p-survey-chart__response-count u-hide--small">428 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Platform Engineer</strong>
-              <span class="p-survey-chart__response-count">235 responses</span>
+              <strong class="u-truncate">Platform Engineer</strong>
+              <span class="p-survey-chart__response-count u-hide--small">235 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">14.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">14.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 14.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Self-serve admin</strong>
-              <span class="p-survey-chart__response-count">169 responses</span>
+              <strong class="u-truncate">Self-serve admin</strong>
+              <span class="p-survey-chart__response-count u-hide--small">169 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>SRE</strong>
-              <span class="p-survey-chart__response-count">131 responses</span>
+              <strong class="u-truncate">SRE</strong>
+              <span class="p-survey-chart__response-count u-hide--small">131 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Our Intern</strong>
-              <span class="p-survey-chart__response-count">90 responses</span>
+              <strong class="u-truncate">Our Intern</strong>
+              <span class="p-survey-chart__response-count u-hide--small">90 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Managed service</strong>
-              <span class="p-survey-chart__response-count">88 responses</span>
+              <strong class="u-truncate">Managed service</strong>
+              <span class="p-survey-chart__response-count u-hide--small">88 responses</span>
             </div>
           </div>
         </div>
@@ -4886,111 +4886,111 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">46.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">46.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 46.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>How secure is that thing?</strong>
-              <span class="p-survey-chart__response-count">527 responses</span>
+              <strong class="u-truncate">How secure is that thing?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">527 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">26.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">26.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 26.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>How can we optimize resource utilization?</strong>
-              <span class="p-survey-chart__response-count">301 responses</span>
+              <strong class="u-truncate">How can we optimize resource utilization?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">301 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">24.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">24.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 24.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>How can we optimize applications to reduce work/errors in Day 2 operations?</strong>
-              <span class="p-survey-chart__response-count">284 responses</span>
+              <strong class="u-truncate">How can we optimize applications to reduce work/errors in Day 2 operations?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">284 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>What resources should be allocated to the scenario?</strong>
-              <span class="p-survey-chart__response-count">234 responses</span>
+              <strong class="u-truncate">What resources should be allocated to the scenario?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">234 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">18.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">18.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 18.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Where should the application run?</strong>
-              <span class="p-survey-chart__response-count">207 responses</span>
+              <strong class="u-truncate">Where should the application run?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">207 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Which software components should be included in the workflow?</strong>
-              <span class="p-survey-chart__response-count">200 responses</span>
+              <strong class="u-truncate">Which software components should be included in the workflow?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">200 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17%;"></div>
             <div class="p-survey-chart__content">
-              <strong>What is happening in that YAML file?</strong>
-              <span class="p-survey-chart__response-count">194 responses</span>
+              <strong class="u-truncate">What is happening in that YAML file?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">194 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>What&rsquo;s the fastest way to deploy X?</strong>
-              <span class="p-survey-chart__response-count">158 responses</span>
+              <strong class="u-truncate">What&rsquo;s the fastest way to deploy X?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">158 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>What is happening in that helm chart?</strong>
-              <span class="p-survey-chart__response-count">96 responses</span>
+              <strong class="u-truncate">What is happening in that helm chart?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">96 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>How should that scenario be integrated into the wider estate?</strong>
-              <span class="p-survey-chart__response-count">81 responses</span>
+              <strong class="u-truncate">How should that scenario be integrated into the wider estate?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">81 responses</span>
             </div>
           </div>
         </div>
@@ -5083,45 +5083,45 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">44.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">44.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 44.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Just one</strong>
-              <span class="p-survey-chart__response-count">511 responses</span>
+              <strong class="u-truncate">Just one</strong>
+              <span class="p-survey-chart__response-count u-hide--small">511 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">19.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">19.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 19.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A team of at least 9</strong>
-              <span class="p-survey-chart__response-count">224 responses</span>
+              <strong class="u-truncate">A team of at least 9</strong>
+              <span class="p-survey-chart__response-count u-hide--small">224 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">203 responses</span>
+              <strong class="u-truncate">Don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">203 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Kubernetes is unscrewable</strong>
-              <span class="p-survey-chart__response-count">202 responses</span>
+              <strong class="u-truncate">Kubernetes is unscrewable</strong>
+              <span class="p-survey-chart__response-count u-hide--small">202 responses</span>
             </div>
           </div>
         </div>
@@ -5159,243 +5159,243 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">32.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">32.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 32.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Continuous Integration &amp; Delivery</strong>
-              <span class="p-survey-chart__response-count">370 responses</span>
+              <strong class="u-truncate">Continuous Integration &amp; Delivery</strong>
+              <span class="p-survey-chart__response-count u-hide--small">370 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">24.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">24.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 24.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>None &mdash; I&rsquo;m pretty good at some of them, but master of none</strong>
-              <span class="p-survey-chart__response-count">279 responses</span>
+              <strong class="u-truncate">None &mdash; I&rsquo;m pretty good at some of them, but master of none</strong>
+              <span class="p-survey-chart__response-count u-hide--small">279 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">23.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">23.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 23.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>None &mdash; I&rsquo;m still learning</strong>
-              <span class="p-survey-chart__response-count">265 responses</span>
+              <strong class="u-truncate">None &mdash; I&rsquo;m still learning</strong>
+              <span class="p-survey-chart__response-count u-hide--small">265 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Application Definition &amp; Image Build</strong>
-              <span class="p-survey-chart__response-count">261 responses</span>
+              <strong class="u-truncate">Application Definition &amp; Image Build</strong>
+              <span class="p-survey-chart__response-count u-hide--small">261 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Database</strong>
-              <span class="p-survey-chart__response-count">259 responses</span>
+              <strong class="u-truncate">Database</strong>
+              <span class="p-survey-chart__response-count u-hide--small">259 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Automations &amp; Configuration</strong>
-              <span class="p-survey-chart__response-count">258 responses</span>
+              <strong class="u-truncate">Automations &amp; Configuration</strong>
+              <span class="p-survey-chart__response-count u-hide--small">258 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">19.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">19.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 19.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>API Gateway</strong>
-              <span class="p-survey-chart__response-count">221 responses</span>
+              <strong class="u-truncate">API Gateway</strong>
+              <span class="p-survey-chart__response-count u-hide--small">221 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">19.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">19.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 19.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Container Registry</strong>
-              <span class="p-survey-chart__response-count">220 responses</span>
+              <strong class="u-truncate">Container Registry</strong>
+              <span class="p-survey-chart__response-count u-hide--small">220 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Container Runtime</strong>
-              <span class="p-survey-chart__response-count">184 responses</span>
+              <strong class="u-truncate">Container Runtime</strong>
+              <span class="p-survey-chart__response-count u-hide--small">184 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Ingress/Service Proxy</strong>
-              <span class="p-survey-chart__response-count">176 responses</span>
+              <strong class="u-truncate">Ingress/Service Proxy</strong>
+              <span class="p-survey-chart__response-count u-hide--small">176 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">14.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">14.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 14.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Observability</strong>
-              <span class="p-survey-chart__response-count">163 responses</span>
+              <strong class="u-truncate">Observability</strong>
+              <span class="p-survey-chart__response-count u-hide--small">163 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Cloud Native Storage</strong>
-              <span class="p-survey-chart__response-count">150 responses</span>
+              <strong class="u-truncate">Cloud Native Storage</strong>
+              <span class="p-survey-chart__response-count u-hide--small">150 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Security &amp; Compliance</strong>
-              <span class="p-survey-chart__response-count">133 responses</span>
+              <strong class="u-truncate">Security &amp; Compliance</strong>
+              <span class="p-survey-chart__response-count u-hide--small">133 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Scheduling &amp; Orchestration</strong>
-              <span class="p-survey-chart__response-count">132 responses</span>
+              <strong class="u-truncate">Scheduling &amp; Orchestration</strong>
+              <span class="p-survey-chart__response-count u-hide--small">132 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Serverless/Function-as-a-Service</strong>
-              <span class="p-survey-chart__response-count">123 responses</span>
+              <strong class="u-truncate">Serverless/Function-as-a-Service</strong>
+              <span class="p-survey-chart__response-count u-hide--small">123 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Cloud Native Network</strong>
-              <span class="p-survey-chart__response-count">122 responses</span>
+              <strong class="u-truncate">Cloud Native Network</strong>
+              <span class="p-survey-chart__response-count u-hide--small">122 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Streaming &amp; Messaging</strong>
-              <span class="p-survey-chart__response-count">116 responses</span>
+              <strong class="u-truncate">Streaming &amp; Messaging</strong>
+              <span class="p-survey-chart__response-count u-hide--small">116 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Service Mesh</strong>
-              <span class="p-survey-chart__response-count">115 responses</span>
+              <strong class="u-truncate">Service Mesh</strong>
+              <span class="p-survey-chart__response-count u-hide--small">115 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Chaos Engineering</strong>
-              <span class="p-survey-chart__response-count">90 responses</span>
+              <strong class="u-truncate">Chaos Engineering</strong>
+              <span class="p-survey-chart__response-count u-hide--small">90 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Key Management</strong>
-              <span class="p-survey-chart__response-count">90 responses</span>
+              <strong class="u-truncate">Key Management</strong>
+              <span class="p-survey-chart__response-count u-hide--small">90 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Remote Procedure Call</strong>
-              <span class="p-survey-chart__response-count">63 responses</span>
+              <strong class="u-truncate">Remote Procedure Call</strong>
+              <span class="p-survey-chart__response-count u-hide--small">63 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Coordination &amp; Service Discovery</strong>
-              <span class="p-survey-chart__response-count">56 responses</span>
+              <strong class="u-truncate">Coordination &amp; Service Discovery</strong>
+              <span class="p-survey-chart__response-count u-hide--small">56 responses</span>
             </div>
           </div>
         </div>
@@ -5460,23 +5460,23 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">72.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">72.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 72.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>True</strong>
-              <span class="p-survey-chart__response-count">820 responses</span>
+              <strong class="u-truncate">True</strong>
+              <span class="p-survey-chart__response-count u-hide--small">820 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">27.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">27.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 27.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>False</strong>
-              <span class="p-survey-chart__response-count">314 responses</span>
+              <strong class="u-truncate">False</strong>
+              <span class="p-survey-chart__response-count u-hide--small">314 responses</span>
             </div>
           </div>
         </div>
@@ -5512,67 +5512,67 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">30.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">30.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 30.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A software extension that uses custom resources to operate applications</strong>
-              <span class="p-survey-chart__response-count">349 responses</span>
+              <strong class="u-truncate">A software extension that uses custom resources to operate applications</strong>
+              <span class="p-survey-chart__response-count u-hide--small">349 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">198 responses</span>
+              <strong class="u-truncate">Don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">198 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A Go application that can talk to the Kubernetes API</strong>
-              <span class="p-survey-chart__response-count">175 responses</span>
+              <strong class="u-truncate">A Go application that can talk to the Kubernetes API</strong>
+              <span class="p-survey-chart__response-count u-hide--small">175 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A master.yaml file used to deploy multiple applications</strong>
-              <span class="p-survey-chart__response-count">174 responses</span>
+              <strong class="u-truncate">A master.yaml file used to deploy multiple applications</strong>
+              <span class="p-survey-chart__response-count u-hide--small">174 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>An IT person with experience in operating Kubernetes</strong>
-              <span class="p-survey-chart__response-count">157 responses</span>
+              <strong class="u-truncate">An IT person with experience in operating Kubernetes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">157 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>A helm chart that can be dynamically modified at execution time</strong>
-              <span class="p-survey-chart__response-count">88 responses</span>
+              <strong class="u-truncate">A helm chart that can be dynamically modified at execution time</strong>
+              <span class="p-survey-chart__response-count u-hide--small">88 responses</span>
             </div>
           </div>
         </div>
@@ -5679,100 +5679,100 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">29.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">29.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 29.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Trying them out is on my to-do list</strong>
-              <span class="p-survey-chart__response-count">338 responses</span>
+              <strong class="u-truncate">Trying them out is on my to-do list</strong>
+              <span class="p-survey-chart__response-count u-hide--small">338 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Getting comfortable with them</strong>
-              <span class="p-survey-chart__response-count">191 responses</span>
+              <strong class="u-truncate">Getting comfortable with them</strong>
+              <span class="p-survey-chart__response-count u-hide--small">191 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Using them for apps in production</strong>
-              <span class="p-survey-chart__response-count">156 responses</span>
+              <strong class="u-truncate">Using them for apps in production</strong>
+              <span class="p-survey-chart__response-count u-hide--small">156 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">129 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">129 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Most useful invention since pizza</strong>
-              <span class="p-survey-chart__response-count">84 responses</span>
+              <strong class="u-truncate">Most useful invention since pizza</strong>
+              <span class="p-survey-chart__response-count u-hide--small">84 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Tried one, failed miserably</strong>
-              <span class="p-survey-chart__response-count">69 responses</span>
+              <strong class="u-truncate">Tried one, failed miserably</strong>
+              <span class="p-survey-chart__response-count u-hide--small">69 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t care for them</strong>
-              <span class="p-survey-chart__response-count">62 responses</span>
+              <strong class="u-truncate">Don&rsquo;t care for them</strong>
+              <span class="p-survey-chart__response-count u-hide--small">62 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t need them</strong>
-              <span class="p-survey-chart__response-count">55 responses</span>
+              <strong class="u-truncate">Don&rsquo;t need them</strong>
+              <span class="p-survey-chart__response-count u-hide--small">55 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>We have security concerns</strong>
-              <span class="p-survey-chart__response-count">52 responses</span>
+              <strong class="u-truncate">We have security concerns</strong>
+              <span class="p-survey-chart__response-count u-hide--small">52 responses</span>
             </div>
           </div>
         </div>
@@ -5783,111 +5783,111 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">31.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">31.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 31%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Trying them out is on my to-do list</strong>
-              <span class="p-survey-chart__response-count">352 responses</span>
+              <strong class="u-truncate">Trying them out is on my to-do list</strong>
+              <span class="p-survey-chart__response-count u-hide--small">352 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">14.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">14.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 14.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">165 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">165 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">13.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">13.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 13.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>How are these different from the others?</strong>
-              <span class="p-survey-chart__response-count">154 responses</span>
+              <strong class="u-truncate">How are these different from the others?</strong>
+              <span class="p-survey-chart__response-count u-hide--small">154 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t care for them</strong>
-              <span class="p-survey-chart__response-count">92 responses</span>
+              <strong class="u-truncate">Don&rsquo;t care for them</strong>
+              <span class="p-survey-chart__response-count u-hide--small">92 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Getting comfortable with them</strong>
-              <span class="p-survey-chart__response-count">83 responses</span>
+              <strong class="u-truncate">Getting comfortable with them</strong>
+              <span class="p-survey-chart__response-count u-hide--small">83 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Don&rsquo;t need them</strong>
-              <span class="p-survey-chart__response-count">70 responses</span>
+              <strong class="u-truncate">Don&rsquo;t need them</strong>
+              <span class="p-survey-chart__response-count u-hide--small">70 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">5.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">5.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 5.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Using them for apps in production</strong>
-              <span class="p-survey-chart__response-count">67 responses</span>
+              <strong class="u-truncate">Using them for apps in production</strong>
+              <span class="p-survey-chart__response-count u-hide--small">67 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>We have security concerns</strong>
-              <span class="p-survey-chart__response-count">54 responses</span>
+              <strong class="u-truncate">We have security concerns</strong>
+              <span class="p-survey-chart__response-count u-hide--small">54 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Tried one, failed miserably</strong>
-              <span class="p-survey-chart__response-count">51 responses</span>
+              <strong class="u-truncate">Tried one, failed miserably</strong>
+              <span class="p-survey-chart__response-count u-hide--small">51 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">4.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">4.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 4.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Most useful invention since pizza</strong>
-              <span class="p-survey-chart__response-count">47 responses</span>
+              <strong class="u-truncate">Most useful invention since pizza</strong>
+              <span class="p-survey-chart__response-count u-hide--small">47 responses</span>
             </div>
           </div>
         </div>
@@ -5925,78 +5925,78 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Make coffee</strong>
-              <span class="p-survey-chart__response-count">256 responses</span>
+              <strong class="u-truncate">Make coffee</strong>
+              <span class="p-survey-chart__response-count u-hide--small">256 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">18.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">18.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 18.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Automate the integration of cloud services with my on-prem applications</strong>
-              <span class="p-survey-chart__response-count">207 responses</span>
+              <strong class="u-truncate">Automate the integration of cloud services with my on-prem applications</strong>
+              <span class="p-survey-chart__response-count u-hide--small">207 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Have visibility around failure predictions of my Kubernetes clusters</strong>
-              <span class="p-survey-chart__response-count">197 responses</span>
+              <strong class="u-truncate">Have visibility around failure predictions of my Kubernetes clusters</strong>
+              <span class="p-survey-chart__response-count u-hide--small">197 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Integrate legacy/MVC applications running on VMs with my containers</strong>
-              <span class="p-survey-chart__response-count">190 responses</span>
+              <strong class="u-truncate">Integrate legacy/MVC applications running on VMs with my containers</strong>
+              <span class="p-survey-chart__response-count u-hide--small">190 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I have a monolith the company worships</strong>
-              <span class="p-survey-chart__response-count">135 responses</span>
+              <strong class="u-truncate">I have a monolith the company worships</strong>
+              <span class="p-survey-chart__response-count u-hide--small">135 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I can do everything I need using Kubernetes</strong>
-              <span class="p-survey-chart__response-count">123 responses</span>
+              <strong class="u-truncate">I can do everything I need using Kubernetes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">123 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">28 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">28 responses</span>
             </div>
           </div>
         </div>
@@ -6055,100 +6055,100 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">56.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">56.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 56%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Security &mdash; passed vulnerability and malware scanning</strong>
-              <span class="p-survey-chart__response-count">639 responses</span>
+              <strong class="u-truncate">Security &mdash; passed vulnerability and malware scanning</strong>
+              <span class="p-survey-chart__response-count u-hide--small">639 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">38.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">38.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 38.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Stability &mdash; long term supported versions</strong>
-              <span class="p-survey-chart__response-count">443 responses</span>
+              <strong class="u-truncate">Stability &mdash; long term supported versions</strong>
+              <span class="p-survey-chart__response-count u-hide--small">443 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">38.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">38.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 38.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Size &mdash; lightweight images</strong>
-              <span class="p-survey-chart__response-count">437 responses</span>
+              <strong class="u-truncate">Size &mdash; lightweight images</strong>
+              <span class="p-survey-chart__response-count u-hide--small">437 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">37.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">37.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 37.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Compliance &mdash; with your company policies or a standard</strong>
-              <span class="p-survey-chart__response-count">432 responses</span>
+              <strong class="u-truncate">Compliance &mdash; with your company policies or a standard</strong>
+              <span class="p-survey-chart__response-count u-hide--small">432 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">37.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">37.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 37.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Provenance &mdash; getting the image from a trusted publisher</strong>
-              <span class="p-survey-chart__response-count">426 responses</span>
+              <strong class="u-truncate">Provenance &mdash; getting the image from a trusted publisher</strong>
+              <span class="p-survey-chart__response-count u-hide--small">426 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">27.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">27.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 27.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Developer experience &mdash; frictionless usability of the image, Size &mdash; lightweight images, Stability &mdash; long term supported versions</strong>
-              <span class="p-survey-chart__response-count">309 responses</span>
+              <strong class="u-truncate">Developer experience &mdash; frictionless usability of the image, Size &mdash; lightweight images, Stability &mdash; long term supported versions</strong>
+              <span class="p-survey-chart__response-count u-hide--small">309 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Ready-to-use &mdash; default packages and tools included</strong>
-              <span class="p-survey-chart__response-count">262 responses</span>
+              <strong class="u-truncate">Ready-to-use &mdash; default packages and tools included</strong>
+              <span class="p-survey-chart__response-count u-hide--small">262 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">21.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">21.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 21.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Base layer &mdash; preference for an Alpine, UBI, Ubuntu, etc</strong>
-              <span class="p-survey-chart__response-count">248 responses</span>
+              <strong class="u-truncate">Base layer &mdash; preference for an Alpine, UBI, Ubuntu, etc</strong>
+              <span class="p-survey-chart__response-count u-hide--small">248 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Price &mdash; lowest cost for pulling or running the image</strong>
-              <span class="p-survey-chart__response-count">230 responses</span>
+              <strong class="u-truncate">Price &mdash; lowest cost for pulling or running the image</strong>
+              <span class="p-survey-chart__response-count u-hide--small">230 responses</span>
             </div>
           </div>
         </div>
@@ -6207,45 +6207,45 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">37.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">37.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 37%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes, in production</strong>
-              <span class="p-survey-chart__response-count">422 responses</span>
+              <strong class="u-truncate">Yes, in production</strong>
+              <span class="p-survey-chart__response-count u-hide--small">422 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes, evaluating</strong>
-              <span class="p-survey-chart__response-count">253 responses</span>
+              <strong class="u-truncate">Yes, evaluating</strong>
+              <span class="p-survey-chart__response-count u-hide--small">253 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">21.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">21.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 21.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>No, stateless applications only</strong>
-              <span class="p-survey-chart__response-count">242 responses</span>
+              <strong class="u-truncate">No, stateless applications only</strong>
+              <span class="p-survey-chart__response-count u-hide--small">242 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">19.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">19.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 19.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>No, but planning to in the next 12 months</strong>
-              <span class="p-survey-chart__response-count">224 responses</span>
+              <strong class="u-truncate">No, but planning to in the next 12 months</strong>
+              <span class="p-survey-chart__response-count u-hide--small">224 responses</span>
             </div>
           </div>
         </div>
@@ -6281,56 +6281,56 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">63.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">63.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 63%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Namespaces</strong>
-              <span class="p-survey-chart__response-count">715 responses</span>
+              <strong class="u-truncate">Namespaces</strong>
+              <span class="p-survey-chart__response-count u-hide--small">715 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">39.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">39.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 39.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Separate clusters</strong>
-              <span class="p-survey-chart__response-count">449 responses</span>
+              <strong class="u-truncate">Separate clusters</strong>
+              <span class="p-survey-chart__response-count u-hide--small">449 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">38.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">38.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 38.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Labels</strong>
-              <span class="p-survey-chart__response-count">433 responses</span>
+              <strong class="u-truncate">Labels</strong>
+              <span class="p-survey-chart__response-count u-hide--small">433 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Not applicable to me or don&rsquo;t know</strong>
-              <span class="p-survey-chart__response-count">257 responses</span>
+              <strong class="u-truncate">Not applicable to me or don&rsquo;t know</strong>
+              <span class="p-survey-chart__response-count u-hide--small">257 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">0.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">0.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 0.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">6 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">6 responses</span>
             </div>
           </div>
         </div>
@@ -6389,23 +6389,23 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">54.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">54.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 54.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes</strong>
-              <span class="p-survey-chart__response-count">617 responses</span>
+              <strong class="u-truncate">Yes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">617 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">45.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">45.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 45.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>No</strong>
-              <span class="p-survey-chart__response-count">522 responses</span>
+              <strong class="u-truncate">No</strong>
+              <span class="p-survey-chart__response-count u-hide--small">522 responses</span>
             </div>
           </div>
         </div>
@@ -6416,23 +6416,23 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">27.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">27.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 27.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes</strong>
-              <span class="p-survey-chart__response-count">308 responses</span>
+              <strong class="u-truncate">Yes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">308 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">72.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">72.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 72.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>No</strong>
-              <span class="p-survey-chart__response-count">830 responses</span>
+              <strong class="u-truncate">No</strong>
+              <span class="p-survey-chart__response-count u-hide--small">830 responses</span>
             </div>
           </div>
         </div>
@@ -6443,23 +6443,23 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">34.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">34.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 34.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Yes</strong>
-              <span class="p-survey-chart__response-count">390 responses</span>
+              <strong class="u-truncate">Yes</strong>
+              <span class="p-survey-chart__response-count u-hide--small">390 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">65.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">65.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 65.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>No</strong>
-              <span class="p-survey-chart__response-count">746 responses</span>
+              <strong class="u-truncate">No</strong>
+              <span class="p-survey-chart__response-count u-hide--small">746 responses</span>
             </div>
           </div>
         </div>
@@ -6496,34 +6496,34 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">43.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">43.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 43.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>exit</strong>
-              <span class="p-survey-chart__response-count">499 responses</span>
+              <strong class="u-truncate">exit</strong>
+              <span class="p-survey-chart__response-count u-hide--small">499 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">31.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">31.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 31.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>echo 'true'</strong>
-              <span class="p-survey-chart__response-count">360 responses</span>
+              <strong class="u-truncate">echo 'true'</strong>
+              <span class="p-survey-chart__response-count u-hide--small">360 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">25.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">25.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 25.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>return 1</strong>
-              <span class="p-survey-chart__response-count">288 responses</span>
+              <strong class="u-truncate">return 1</strong>
+              <span class="p-survey-chart__response-count u-hide--small">288 responses</span>
             </div>
           </div>
         </div>
@@ -6540,166 +6540,166 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">36.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">36.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 36.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>I don&rsquo;t have an edge usecase</strong>
-              <span class="p-survey-chart__response-count">423 responses</span>
+              <strong class="u-truncate">I don&rsquo;t have an edge usecase</strong>
+              <span class="p-survey-chart__response-count u-hide--small">423 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Data centers &amp; CDNs</strong>
-              <span class="p-survey-chart__response-count">198 responses</span>
+              <strong class="u-truncate">Data centers &amp; CDNs</strong>
+              <span class="p-survey-chart__response-count u-hide--small">198 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">15.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">15.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 15.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Manufacturing/industrial IT</strong>
-              <span class="p-survey-chart__response-count">182 responses</span>
+              <strong class="u-truncate">Manufacturing/industrial IT</strong>
+              <span class="p-survey-chart__response-count u-hide--small">182 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Telco/MEC</strong>
-              <span class="p-survey-chart__response-count">147 responses</span>
+              <strong class="u-truncate">Telco/MEC</strong>
+              <span class="p-survey-chart__response-count u-hide--small">147 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Living on the edge</strong>
-              <span class="p-survey-chart__response-count">137 responses</span>
+              <strong class="u-truncate">Living on the edge</strong>
+              <span class="p-survey-chart__response-count u-hide--small">137 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Healthcare</strong>
-              <span class="p-survey-chart__response-count">132 responses</span>
+              <strong class="u-truncate">Healthcare</strong>
+              <span class="p-survey-chart__response-count u-hide--small">132 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">10.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">10.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 10.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Image processing</strong>
-              <span class="p-survey-chart__response-count">120 responses</span>
+              <strong class="u-truncate">Image processing</strong>
+              <span class="p-survey-chart__response-count u-hide--small">120 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">9.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">9.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 9.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Education &amp; workplaces</strong>
-              <span class="p-survey-chart__response-count">112 responses</span>
+              <strong class="u-truncate">Education &amp; workplaces</strong>
+              <span class="p-survey-chart__response-count u-hide--small">112 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Automotive &amp; transportation</strong>
-              <span class="p-survey-chart__response-count">95 responses</span>
+              <strong class="u-truncate">Automotive &amp; transportation</strong>
+              <span class="p-survey-chart__response-count u-hide--small">95 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.4%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.4%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Smart buildings &amp; cities</strong>
-              <span class="p-survey-chart__response-count">85 responses</span>
+              <strong class="u-truncate">Smart buildings &amp; cities</strong>
+              <span class="p-survey-chart__response-count u-hide--small">85 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Retail</strong>
-              <span class="p-survey-chart__response-count">81 responses</span>
+              <strong class="u-truncate">Retail</strong>
+              <span class="p-survey-chart__response-count u-hide--small">81 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Energy</strong>
-              <span class="p-survey-chart__response-count">75 responses</span>
+              <strong class="u-truncate">Energy</strong>
+              <span class="p-survey-chart__response-count u-hide--small">75 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Residential/smart home</strong>
-              <span class="p-survey-chart__response-count">69 responses</span>
+              <strong class="u-truncate">Residential/smart home</strong>
+              <span class="p-survey-chart__response-count u-hide--small">69 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">3.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">3.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 3.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Agriculture</strong>
-              <span class="p-survey-chart__response-count">40 responses</span>
+              <strong class="u-truncate">Agriculture</strong>
+              <span class="p-survey-chart__response-count u-hide--small">40 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">2.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">2.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 2.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Other</strong>
-              <span class="p-survey-chart__response-count">26 responses</span>
+              <strong class="u-truncate">Other</strong>
+              <span class="p-survey-chart__response-count u-hide--small">26 responses</span>
             </div>
           </div>
         </div>
@@ -6710,188 +6710,188 @@
 
       <div class="p-survey-chart">
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">48.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">48.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 48.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Security and compliance</strong>
-              <span class="p-survey-chart__response-count">355 responses</span>
+              <strong class="u-truncate">Security and compliance</strong>
+              <span class="p-survey-chart__response-count u-hide--small">355 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">44.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">44.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 44.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Low latency</strong>
-              <span class="p-survey-chart__response-count">321 responses</span>
+              <strong class="u-truncate">Low latency</strong>
+              <span class="p-survey-chart__response-count u-hide--small">321 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">42.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">42.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 42.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Scalability</strong>
-              <span class="p-survey-chart__response-count">310 responses</span>
+              <strong class="u-truncate">Scalability</strong>
+              <span class="p-survey-chart__response-count u-hide--small">310 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">30.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">30.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 30.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Observability</strong>
-              <span class="p-survey-chart__response-count">222 responses</span>
+              <strong class="u-truncate">Observability</strong>
+              <span class="p-survey-chart__response-count u-hide--small">222 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">28.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">28.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 28.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Resource allocation</strong>
-              <span class="p-survey-chart__response-count">204 responses</span>
+              <strong class="u-truncate">Resource allocation</strong>
+              <span class="p-survey-chart__response-count u-hide--small">204 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">22.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">22.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 22.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Network support</strong>
-              <span class="p-survey-chart__response-count">164 responses</span>
+              <strong class="u-truncate">Network support</strong>
+              <span class="p-survey-chart__response-count u-hide--small">164 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">20.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">20.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 20.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Supported platforms (Linux flavors, Windows hosts, etc.)</strong>
-              <span class="p-survey-chart__response-count">147 responses</span>
+              <strong class="u-truncate">Supported platforms (Linux flavors, Windows hosts, etc.)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">147 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.6%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.6%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.6%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Offline mode experience</strong>
-              <span class="p-survey-chart__response-count">128 responses</span>
+              <strong class="u-truncate">Offline mode experience</strong>
+              <span class="p-survey-chart__response-count u-hide--small">128 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">17.3%</span>
+          <span class="p-survey-chart__percentage u-hide--small">17.3%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 17.3%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Provisioning &amp; management of the edge fleet</strong>
-              <span class="p-survey-chart__response-count">126 responses</span>
+              <strong class="u-truncate">Provisioning &amp; management of the edge fleet</strong>
+              <span class="p-survey-chart__response-count u-hide--small">126 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">16.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">16.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 16.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>GPUs for AI/ML</strong>
-              <span class="p-survey-chart__response-count">122 responses</span>
+              <strong class="u-truncate">GPUs for AI/ML</strong>
+              <span class="p-survey-chart__response-count u-hide--small">122 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">12.1%</span>
+          <span class="p-survey-chart__percentage u-hide--small">12.1%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 12.1%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Service mesh support</strong>
-              <span class="p-survey-chart__response-count">88 responses</span>
+              <strong class="u-truncate">Service mesh support</strong>
+              <span class="p-survey-chart__response-count u-hide--small">88 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">11.0%</span>
+          <span class="p-survey-chart__percentage u-hide--small">11.0%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 11%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Ability to create a 1 or 2 node cluster</strong>
-              <span class="p-survey-chart__response-count">80 responses</span>
+              <strong class="u-truncate">Ability to create a 1 or 2 node cluster</strong>
+              <span class="p-survey-chart__response-count u-hide--small">80 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.9%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.9%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.9%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Device &ldquo;phone home&rdquo;</strong>
-              <span class="p-survey-chart__response-count">65 responses</span>
+              <strong class="u-truncate">Device &ldquo;phone home&rdquo;</strong>
+              <span class="p-survey-chart__response-count u-hide--small">65 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">8.5%</span>
+          <span class="p-survey-chart__percentage u-hide--small">8.5%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 8.5%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Message brokers support</strong>
-              <span class="p-survey-chart__response-count">62 responses</span>
+              <strong class="u-truncate">Message brokers support</strong>
+              <span class="p-survey-chart__response-count u-hide--small">62 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.8%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.8%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.8%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Specific communications protocol support</strong>
-              <span class="p-survey-chart__response-count">57 responses</span>
+              <strong class="u-truncate">Specific communications protocol support</strong>
+              <span class="p-survey-chart__response-count u-hide--small">57 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">7.2%</span>
+          <span class="p-survey-chart__percentage u-hide--small">7.2%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 7.2%;"></div>
             <div class="p-survey-chart__content">
-              <strong>EPA features (SR-IOV, DPDK, Numa, etc)</strong>
-              <span class="p-survey-chart__response-count">52 responses</span>
+              <strong class="u-truncate">EPA features (SR-IOV, DPDK, Numa, etc)</strong>
+              <span class="p-survey-chart__response-count u-hide--small">52 responses</span>
             </div>
           </div>
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage">6.7%</span>
+          <span class="p-survey-chart__percentage u-hide--small">6.7%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 6.7%;"></div>
             <div class="p-survey-chart__content">
-              <strong>Diversified edge gateway and leaf devices</strong>
-              <span class="p-survey-chart__response-count">49 responses</span>
+              <strong class="u-truncate">Diversified edge gateway and leaf devices</strong>
+              <span class="p-survey-chart__response-count u-hide--small">49 responses</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Done
Made the survey report charts more legible on mobile

## QA
- Go to https://juju-is-284.demos.haus/cloud-native-kubernetes-usage-report-2021
- Resize viewport to mobile width
- Compare charts against those on [the live page](https://juju.is/cloud-native-kubernetes-usage-report-2021)
- Check that they are more legible

## Issue
Fixes #282 

## Screenshots

### Before
<img width="327" alt="Screenshot 2021-06-25 at 10 17 45" src="https://user-images.githubusercontent.com/501889/123401488-c2855880-d59e-11eb-8731-de9ce606161a.png">

### After
<img width="327" alt="Screenshot 2021-06-25 at 10 17 55" src="https://user-images.githubusercontent.com/501889/123401514-cadd9380-d59e-11eb-9f57-7a7c9a23d6a5.png">
