### PR TITLE
Update copy on k8s report

### DIFF
--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -609,7 +609,7 @@
             <div class="p-media-object--large u-no-margin--bottom">
               {{
                 image(
-                  url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+                  url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
                   alt="",
                   height="96",
                   width="96",
@@ -659,6 +659,7 @@
                 </ul>
               </div>
             </div>
+            <p>James works on Jenkins X to help developers automate their CI/CD for cloud native applications and help them go faster. James also created the Groovy programming language and the Apache Camel integration framework</p>
           </div>
           <div class="col-2 p-divider__block u-align--center u-vertically-center">
             {{
@@ -676,6 +677,8 @@
       </div>
 
       <hr style="margin-bottom: 3rem;">
+
+      <h2 class="p-heading--1">The Kubernetes and Cloud Native Operations Report 2021</h2>
 
       <h2 id="who-is-using-kubernetes-and-cloud-native-technologies">Who is using Kubernetes and cloud native technologies?</h2>
 
@@ -1887,7 +1890,7 @@
       <div class="p-media-object--large is-reversed">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -2939,7 +2942,7 @@
       <div class="p-media-object--large">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -3338,7 +3341,7 @@
       <div class="p-media-object--large">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -3921,7 +3924,7 @@
       <div class="p-media-object--large">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -4183,7 +4186,7 @@
       <div class="p-media-object--large">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -4384,7 +4387,7 @@
       <div class="p-media-object--large is-reversed">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -4479,7 +4482,7 @@
       <div class="p-media-object--large is-reversed">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -4698,7 +4701,7 @@
       <div class="p-media-object--large">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -5407,7 +5410,7 @@
       <div class="p-media-object--large">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",
@@ -5631,7 +5634,7 @@
       <div class="p-media-object--large">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ba2dd769-james.jpeg",
+            url="https://assets.ubuntu.com/v1/ba69559c-james+strachen+headshot.jpg",
             alt="",
             height="96",
             width="96",


### PR DESCRIPTION
## Done
Updated copy on the k8s survey report page

## QA
- Go to https://juju-is-290.demos.haus/cloud-native-kubernetes-usage-report-2021
- Check that David's changes from [the copy doc](https://docs.google.com/document/d/1PEcz_9tFvzrvX5U5pBQFqHKC_0wfb8wtE6KD9HEa_Ls/edit#heading=h.17vb3vg0c3mm) have been made, and please resolve them in the copy doc

## Issue
Fixes #285 