### PR TITLE
Fix report navigation link

### DIFF
--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -93,7 +93,7 @@
 
           <h3><a href="#cncf-landscape">CNCF Landscape</a></h3>
           <ul>
-            <li><a href="#cloud-native-technologymastery">Cloud native technology mastery</a></li>
+            <li><a href="#cloud-native-technology-mastery">Cloud native technology mastery</a></li>
           </ul>
 
           <h3><a href="#kubernetes-operators">Kubernetes operators</a></h3>


### PR DESCRIPTION
## Done
Fixed a broken navigation link on the k8s survey report page

## QA
- Go to https://juju-is-291.demos.haus/cloud-native-kubernetes-usage-report-2021
- Find the navigation link "Cloud native technology mastery"
- Click it and check that you are taken to the right section

## Issue
Fixes #292 