### PR TITLE
Add meta image to k8s survey report page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,11 @@
     applications in the cloud{% endblock %}
   </title>
   <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/u/0/folders/1-3OoeHxK5U7W_ktFY8rvwRzmjzCKte9a{% endblock %}">
+  {% if self.meta_image %}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="{{ self.meta_image() }}">
+  <meta property="og:image" content="{{ self.meta_image() }}">
+  {% endif %}
 
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   <script src="https://buttons.github.io/buttons.js" defer></script>
@@ -39,7 +44,7 @@
 
 <body class="{% block page_class %}{% endblock %}">
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9KCMZ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9KCMZ" height="0" width="0" style="display: none; visibility: hidden;"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
 
   {% include "partials/_navigation.html" %}

--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -6,6 +6,8 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1PEcz_9tFvzrvX5U5pBQFqHKC_0wfb8wtE6KD9HEa_Ls/edit#heading=h.qb2r9z9grpt7{% endblock %}
 
+{% block meta_image %}https://assets.ubuntu.com/v1/3d1afa25-K8s_cloud_native_report.png{% endblock %}
+
 {% block content %}
 
 <section class="p-strip--blue is-dark">


### PR DESCRIPTION
## Done
Added meta image to k8s survey report page

## QA
- Go to https://socialsharepreview.com/?url=https://juju-is-296.demos.haus/cloud-native-kubernetes-usage-report-2021
- Check that the social image is visible

## Issue
Fixes #295 