### PR TITLE
Add button to download k8s survey report

### DIFF
--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -11,7 +11,7 @@
 {% block content %}
 
 <section class="p-strip--blue is-dark">
-  <div class="row">
+  <div class="row u-vertically-center">
     <div class="col-6">
       <h1>
         Kubernetes and cloud native operations report&nbsp;2021
@@ -19,6 +19,7 @@
     </div>
     <div class="col-6">
       <p>Data from 1200 respondents on hybrid and multi-cloud operations, Kubernetes, VMs, bare metal, goals, benefits, challenges, operators, advanced usage, edge, and more.</p>
+      <a class="p-button u-no-margin--bottom" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Kubernetes%20cloud%20native%20operations%20report%2006.21.pdf">Download report</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Added a link to the k8s survey report PDF

## QA
- Go to https://juju-is-302.demos.haus/cloud-native-kubernetes-usage-report-2021
- Click the "Download report" button in the hero
- Check that it goes to the report PDF

## Issue
Fixes #301 