### PR TITLE
Add PDF link to survey page

### DIFF
--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -6993,6 +6993,10 @@
       <p><a href="https://ubuntu.com/kubernetes/kubernetes-operations-survey" class="p-button--positive">Take the survey</a></p>
 
       <p>This report will be published bi-annually, a few weeks after every KubeCon event. The next survey iteration is planned for the week of KubeCon NA 2021, and the new report will be launched in November 2021.</p>
+
+      <p>Finally, if you liked what you read here, feel free to share the link to this page or to it&rsquo;s PDF version.</p>
+
+      <p><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Kubernetes%20cloud%20native%20operations%20report%2006.21.pdf" class="p-button--positive">Download the PDF</a></p>
     </main>
   </div>
 </section>

--- a/templates/cloud-native-kubernetes-usage-report-2021/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2021/index.html
@@ -6994,7 +6994,7 @@
 
       <p>This report will be published bi-annually, a few weeks after every KubeCon event. The next survey iteration is planned for the week of KubeCon NA 2021, and the new report will be launched in November 2021.</p>
 
-      <p>Finally, if you liked what you read here, feel free to share the link to this page or to it&rsquo;s PDF version.</p>
+      <p>Finally, if you liked what you read here, feel free to share the link to this page or to its PDF version.</p>
 
       <p><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Kubernetes%20cloud%20native%20operations%20report%2006.21.pdf" class="p-button--positive">Download the PDF</a></p>
     </main>


### PR DESCRIPTION
## Done
Added a button linking to the PDF on the survey report page

## QA
- Go to https://juju-is-304.demos.haus/cloud-native-kubernetes-usage-report-2021
- Check that there is a button at the bottom of the page linking to the PDF
- Check that the copy matches the copy referenced in [this comment](https://github.com/canonical-web-and-design/juju.is/issues/305)
- Resolve the comment

## Issue
Fixes https://github.com/canonical-web-and-design/juju.is/issues/305