### PR TITLE
Fix typo in menu

### DIFF
--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -80,7 +80,7 @@
               <hr>
             </li>
             <li>
-              <p class="p-subnav__item is-title">Join the comunity</p>
+              <p class="p-subnav__item is-title">Join the community</p>
             </li>
             <li>
               <a href="http://discourse.charmhub.io" class="p-subnav__item">Forum</a>


### PR DESCRIPTION
## Done
Fixed typo in the menu

## QA
- Go to https://juju-is-325.demos.haus/
- Click on the "Contribute" menu
- Check that the "JOIN THE COMMUNITY" heading is spelled correctly

## Issue
Fixes #324 