### PR TITLE
Add external link icons to external links in menu

### DIFF
--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -83,13 +83,13 @@
               <p class="p-subnav__item is-title">Join the community</p>
             </li>
             <li>
-              <a href="http://discourse.charmhub.io" class="p-subnav__item">Forum</a>
+              <a href="http://discourse.charmhub.io" class="p-subnav__item p-link--external">Forum</a>
             </li>
             <li>
-              <a href="https://chat.charmhub.io/charmhub/channels/juju" class="p-subnav__item">Chat</a>
+              <a href="https://chat.charmhub.io/charmhub/channels/juju" class="p-subnav__item p-link--external">Chat</a>
             </li>
             <li>
-              <a href="http://bugs.launchpad.net/juju" class="p-subnav__item">Report a bug</a>
+              <a href="http://bugs.launchpad.net/juju" class="p-subnav__item p-link--external">Report a bug</a>
             </li>
             <li>
               <a href="/careers" class="p-subnav__item">Careers</a>


### PR DESCRIPTION
## Done
Added external link icon to external links in the "Contribute" menu

## QA
- Go to https://juju-is-328.demos.haus/
- Check that the external links in the "Contribute" menu have an external link icon

## Issue
Fixes #327 