### PR TITLE
Integrate LMA 2 docs in juju.is navigation

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -37,7 +37,7 @@
         </li>
 
         <li class="p-list__item">
-          <a class="p-link--soft" href="https://juju.is/docs/lma2"><small>Observability (LMA 2)</small></a>
+          <a class="p-link--soft" href="/docs/lma2"><small>Observability (LMA 2)</small></a>
         </li>
 
         <li class="p-list__item">

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -37,7 +37,7 @@
         </li>
 
         <li class="p-list__item">
-          <a class="p-link--soft" href="https://charmhub.io/?base=all&filter=logging-tracing,monitoring"><small>Observability</small></a>
+          <a class="p-link--soft" href="https://juju.is/docs/lma2"><small>Observability (LMA 2)</small></a>
         </li>
 
         <li class="p-list__item">

--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -56,6 +56,9 @@
               <a href="/docs/sdk" class="p-subnav__item">Charmed Operator SDK</a>
             </li>
             <li>
+              <a href="/docs/lma2" class="p-subnav__item">Logs, Metrics and Alerts (LMA) 2</a>
+            </li>
+            <li>
               <a href="/tutorials" class="p-subnav__item">Tutorials</a>
             </li>
             <li>

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -71,6 +71,28 @@ def init_docs(app):
 
     sdk_docs.init_app(app)
 
+    lma2_docs_id = 5132
+    lma2_docs = Docs(
+        parser=DocParser(
+            api=DiscourseAPI(
+                base_url="https://discourse.charmhub.io/",
+                session=session,
+                api_key=DISCOURSE_API_KEY,
+                api_username=DISCOURSE_API_USERNAME,
+                get_topics_query_id=2,
+            ),
+            index_topic_id=lma2_docs_id,
+            url_prefix="/docs/lma2",
+            tutorials_index_topic_id=tutorials_index_topic_id,
+            tutorials_url_prefix=tutorials_url_prefix,
+        ),
+        document_template="docs/document.html",
+        url_prefix="/docs/lma2",
+        blueprint_name="lma2_docs",
+    )
+
+    lma2_docs.init_app(app)
+
     app.add_url_rule(
         "/docs/search",
         "docs-search",


### PR DESCRIPTION
## Done

Include the new LMA 2 Discourse topic as "Learn" and footer entry

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes something that Michele did not actually file as an issue because he likes PRs better :P

## Screenshots

[if relevant, include a screenshot]
