### PR TITLE
Add inclusive naming action

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@v2
 
       - name: Install linkchecker

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -90,3 +90,17 @@ jobs:
         run: |
           SECRET_KEY=insecure_secret_key coverage run  --source=. -m unittest discover tests
           bash <(curl -s https://codecov.io/bash) -cF python
+          
+  check-inclusive-naming:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check inclusive naming
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # juju.is
 
 [![CircleCI build status](https://circleci.com/gh/canonical-web-and-design/juju.is.svg?style=shield)](https://circleci.com/gh/canonical-web-and-design/juju.is)
-[![Code coverage](https://codecov.io/gh/canonical-web-and-design/juju.is/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/juju.is)
+[![Code coverage](https://codecov.io/gh/canonical-web-and-design/juju.is/branch/main/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/juju.is)
 
 This is the repo for the [Juju website](https://juju.is).
 


### PR DESCRIPTION
## Done

- Adds inclusive naming github action
- Replaces key non-inclusive language

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check github action works
- Check language changes make lexical sense


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4496
