### PR TITLE
Update docs link

### DIFF
--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -43,14 +43,14 @@
         <li class="p-navigation__item{% if request.path.startswith('/blog') %} is-selected{% endif %}">
           <a class="p-navigation__link" href="/blog">Blog</a>
         </li>
-        <li class="p-navigation__item p-subnav{% if request.path in [ '/docs', '/docs/sdk', '/docs/sdk/publishing', '/tutorials'] %} is-selected{% endif %}" id="learn-link">
+        <li class="p-navigation__item p-subnav{% if request.path.startswith(("/docs", "/tutorials")) %} is-selected{% endif %}" id="learn-link">
           <a href="#learn-link-menu" aria-controls="learn-link-menu" class="p-subnav__toggle p-navigation__link">Learn</a>
           <ul class="p-subnav__items" id="learn-link-menu" aria-hidden="true">
             <li>
               <p class="p-subnav__item is-title">Documentation</p>
             </li>
             <li>
-              <a href="/docs" class="p-subnav__item">Charmed Operator Lifecycle Manager</a>
+              <a href="/docs/olm" class="p-subnav__item">Charmed Operator Lifecycle Manager</a>
             </li>
             <li>
               <a href="/docs/sdk" class="p-subnav__item">Charmed Operator SDK</a>


### PR DESCRIPTION
## Done
- Replace `/docs` link to `/docs/olm` in the navigation (Fix https://github.com/canonical-web-and-design/juju.is/issues/347)

## QA
- Visit the demo
- Check the first link under the Learn submenu on the navigation is pointing to `/docs/olm`
- Also check that the Learn submenu is active while browsing it.
