### PR TITLE
Set table layout styling to auto site-wide

### DIFF
--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -14,3 +14,6 @@ $color-navigation-active-bar: $color-ubuntu-orange;
 // Sidebar
 $content-padding: 0 5%;
 $sidebar-width: 18rem;
+
+// Configs
+$table-layout-fixed: false;


### PR DESCRIPTION
## Done
Set the $table-layout-fixed Vanilla variable to false site-wide

## QA
- Go to /docs/sdk/storage
- Check the table is easier to read then on live
- Check other docs pages with tables
- _I have checked and the site content does not contain a table_

## Issue / Card
Fixes https://github.com/canonical-web-and-design/juju.is/issues/380

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/152126518-32a72807-f4ae-4eec-b22c-23d90fde0ed5.png)

