### PR TITLE
Pin markupsafe to avoid dependency breakage with 2.x version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ canonicalwebteam.discourse==4.0.8
 canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
+markupsafe<2  # Pin to the latest release of the 1.x branch. 2.x fails with missing symbols
 black==20.8b1
 flake8==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-canonicalwebteam.flask-base==0.9.3
+canonicalwebteam.flask-base==1.0.2
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.yaml-responses==1.2.0
 canonicalwebteam.discourse==4.0.8
 canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-markupsafe<2  # Pin to the latest release of the 1.x branch. 2.x fails with missing symbols
 black==20.8b1
 flake8==4.0.1


### PR DESCRIPTION
## Done

Fix local `dotrun` borkage due to incompatibility with markupsafe 2.x.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
