### PR TITLE
Introduce redirects for pre-topic page LMA2 doc links

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -12,11 +12,4 @@ operator-services/?: /about
 ops-code-quality/?: /about
 overview/?: /about
 universal-operators/?: /about
-docs/lma2/on MicroK8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
-docs/lma2/install/microk8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
-docs/lma2/juju-topology/?: https://charmhub.io/topics/canonical-observability-stack/juju-topology
-docs/lma2/?: https://charmhub.io/topics/canonical-observability-stack
-docs/cos/?: https://charmhub.io/topics/canonical-observability-stack
-docs/cos/on MicroK8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
-docs/cos/install/microk8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
-docs/cos/juju-topology/?: https://charmhub.io/topics/canonical-observability-stack/juju-topology
+docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -12,3 +12,8 @@ operator-services/?: /about
 ops-code-quality/?: /about
 overview/?: /about
 universal-operators/?: /about
+docs/lma2/on MicroK8s/?: /topics/canonical-observability-stack/install/microk8s
+docs/lma2/install/microk8s/?: /topics/canonical-observability-stack/install/microk8s
+docs/lma2/juju-topology/?: /topics/canonical-observability-stack/juju-topology
+docs/lma2/?: /topics/canonical-observability-stack
+docs/cos/?: /topics/canonical-observability-stack

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -12,8 +12,8 @@ operator-services/?: /about
 ops-code-quality/?: /about
 overview/?: /about
 universal-operators/?: /about
-docs/lma2/on MicroK8s/?: /topics/canonical-observability-stack/install/microk8s
-docs/lma2/install/microk8s/?: /topics/canonical-observability-stack/install/microk8s
-docs/lma2/juju-topology/?: /topics/canonical-observability-stack/juju-topology
-docs/lma2/?: /topics/canonical-observability-stack
-docs/cos/?: /topics/canonical-observability-stack
+docs/lma2/on MicroK8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
+docs/lma2/install/microk8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
+docs/lma2/juju-topology/?: https://charmhub.io/topics/canonical-observability-stack/juju-topology
+docs/lma2/?: https://charmhub.io/topics/canonical-observability-stack
+docs/cos/?: https://charmhub.io/topics/canonical-observability-stack

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -17,3 +17,6 @@ docs/lma2/install/microk8s/?: https://charmhub.io/topics/canonical-observability
 docs/lma2/juju-topology/?: https://charmhub.io/topics/canonical-observability-stack/juju-topology
 docs/lma2/?: https://charmhub.io/topics/canonical-observability-stack
 docs/cos/?: https://charmhub.io/topics/canonical-observability-stack
+docs/cos/on MicroK8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
+docs/cos/install/microk8s/?: https://charmhub.io/topics/canonical-observability-stack/install/microk8s
+docs/cos/juju-topology/?: https://charmhub.io/topics/canonical-observability-stack/juju-topology


### PR DESCRIPTION
## Done

Restore via redirects links we have in the wild to the LMa2 (now COS) documentation that used to live under /docs/lma2/...

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
