### PR TITLE
Add page at /operator-day with videos from past events

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==0.9.0
+canonicalwebteam.flask-base==1.0.5
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.yaml-responses==1.2.0
 canonicalwebteam.discourse==4.0.3

--- a/templates/operator-day/index.html
+++ b/templates/operator-day/index.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+
+{% block page_title %}Operator Day - Charmed Operator Framework for Kubernetes and VMs{% endblock page_title %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1ZFRGkZ4vvvMVOgq4MIsBuebHsA7Y0rTyiZ76qjQpOAg/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h1>Operator Day</h1>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>October 2021</h2>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=uWFC1_DeIZU">KubeCon NA 2021: Operator Day Keynote with Mark Shuttleworth</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="302"
+          src="https://www.youtube.com/embed/uWFC1_DeIZU?controls=0"
+          title="KubeCon NA 2021: Operator Day Keynote with Mark Shuttleworth"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <h2>May 2021</h2>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=jDvQrcFE32g">KubeCon Operator Day keynote with Mark Shuttleworth</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="302"
+          src="https://www.youtube.com/embed/jDvQrcFE32g?controls=0"
+          title="KubeCon Operator Day keynote with Mark Shuttleworth"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=yxeJX2WRYjg">How to build a Charmed Operator for Kubernetes</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="302"
+          src="https://www.youtube.com/embed/yxeJX2WRYjg?controls=0"
+          title="How to build a Charmed Operator for Kubernetes"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -64,6 +64,9 @@
             <li>
               <a href="/cloud-native-kubernetes-usage-report-2021" class="p-subnav__item">Kubernetes & Cloud Native Operations Report</a>
             </li>
+            <li>
+              <a href="/operator-day" class="p-subnav__item">Operator Day: videos from KubeCon</a>
+            </li>
           </ul>
         </li>
         <li class="p-navigation__item p-subnav{% if request.path.startswith('/careers') %} is-selected{% endif %}" id="contribute-link">


### PR DESCRIPTION
## Done

- Added /operator-day page based on [copy doc](https://docs.google.com/document/d/1ZFRGkZ4vvvMVOgq4MIsBuebHsA7Y0rTyiZ76qjQpOAg/edit#heading=h.rbuwfvimc6g8)
- It's very barebones, I spoke to [@tmihoc](https://github.com/tmihoc) about it and they're happy for this to go up for the event next week, then iterate when they have time to add more content

## QA

- visit /operator-day
- See that it matches the [copy doc](https://docs.google.com/document/d/1ZFRGkZ4vvvMVOgq4MIsBuebHsA7Y0rTyiZ76qjQpOAg/edit)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5273
