### PR TITLE
Remove the duplicated stat on the k8s report 2022

### DIFF
--- a/templates/cloud-native-kubernetes-usage-report-2022/index.html
+++ b/templates/cloud-native-kubernetes-usage-report-2022/index.html
@@ -783,17 +783,6 @@
         </div>
 
         <div class="p-survey-chart__row">
-          <span class="p-survey-chart__percentage u-hide--small">26.5%</span>
-          <div class="p-survey-chart__bar">
-            <div class="p-survey-chart__result" style="width: 26.5%"></div>
-            <div class="p-survey-chart__content">
-              <strong class="u-truncate">Resource optimization</strong>
-              <span class="p-survey-chart__response-count u-hide--small">337 responses</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="p-survey-chart__row">
           <span class="p-survey-chart__percentage u-hide--small">21.4%</span>
           <div class="p-survey-chart__bar">
             <div class="p-survey-chart__result" style="width: 21.4%"></div>


### PR DESCRIPTION
## Done
Remove the duplicated results for question 4 the line "26.5% Resource optimization 337 responses" appears twice. 

## QA
- Check the code

## Screenshot
![image](https://user-images.githubusercontent.com/1413534/168555660-eb02af1b-b5e0-4625-8f5a-e0b34d6cd8d0.png)
