### PR TITLE
Remove the heading classes to make room on lower resolutions

### DIFF
--- a/templates/partials/_what-is-juju.html
+++ b/templates/partials/_what-is-juju.html
@@ -6,15 +6,15 @@
     <div class="col-7">
       <div class="p-heading-highlight">
         <p class="p-heading-highlight__item p-heading--4">When your team is deploying and managing applications across virtual machines, Kubernetes, hybrid clouds, and multiclouds, it's easy to get lost in the sprawl of YAML, Charts, Recipes, Playbooks, Plans, Scripts, etc.</p>
-        <p class="p-heading--4">Juju is software that drives your software. It helps you to <strong>take control</strong> of all your applications, infrastructure, and environments. You use it to</p>
+        <p>Juju is software that drives your software. It helps you to <strong>take control</strong> of all your applications, infrastructure, and environments. You use it to</p>
         <ul>
-          <li class="p-heading--4 u-no-margin--bottom">Save your team endless hours of script management</li>
-          <li class="p-heading--4 u-no-margin--bottom">Minimise costs</li>
-          <li class="p-heading--4 u-no-margin--bottom">Ensure redundancy and resiliency</li>
-          <li class="p-heading--4 u-no-margin--bottom">Monitor all activity across substrates</li>
-          <li class="p-heading--4 u-no-margin--bottom">Maximise your hybrid cloud architecture</li>
+          <li class="u-no-margin--bottom">Save your team endless hours of script management</li>
+          <li class="u-no-margin--bottom">Minimise costs</li>
+          <li class="u-no-margin--bottom">Ensure redundancy and resiliency</li>
+          <li class="u-no-margin--bottom">Monitor all activity across substrates</li>
+          <li class="u-no-margin--bottom">Maximise your hybrid cloud architecture</li>
         </ul>
-        <p class="p-heading--4">You'll move from <strong>configuration management to application management</strong>.</p>
+        <p>You'll move from <strong>configuration management to application management</strong>.</p>
       </div>
     </div>
     <div class="col-5 u-hide--small">


### PR DESCRIPTION
## Done
Remove the heading classes to make room on lower resolutions

## QA
- Go to the demo
- Scroll down to the "What is Juju?"
- Zoom in a bunch to match the image below of in the issue
- See that the content is now visible

## Issue / Card
Fixes https://github.com/canonical-web-and-design/juju.is/issues/404

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/170006660-e8c87f72-c51b-4147-81cc-0066251d4417.png) | ![image](https://user-images.githubusercontent.com/1413534/170006567-855411a5-59a0-4b76-a381-3bc65723368b.png) |
