### PR TITLE
Docs: Fix margin-bottom for lists with details

### DIFF
--- a/static/sass/_patterns_docs.scss
+++ b/static/sass/_patterns_docs.scss
@@ -111,4 +111,8 @@
     float: right;
     padding: $sp-x-large;
   }
+
+  li:not(:last-child) > details:last-child {
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
## Done

CSS change for discourse docs: Removed margin-bottom when adding `[details]` inside lists

## QA

- visit demo: https://juju-is-413.demos.haus/docs


## Issue / Card

Fixes #407
