### PR TITLE
Update docs template to use expandable side navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "stylelint-config-recommended-scss": "5.0.2",
     "stylelint-order": "5.0.0",
     "stylelint-prettier": "2.0.0",
-    "vanilla-framework": "3.4.0",
+    "vanilla-framework": "3.5.0",
     "watch-cli": "0.2.3"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.0.5
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.yaml-responses==1.2.0
-canonicalwebteam.discourse==4.0.8
+canonicalwebteam.discourse==4.0.9
 canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -1,20 +1,30 @@
 {% extends "docs/base.html" %}
 
 {% block content_docs %}
-{% macro create_navigation(nav_items) %}
-  <ul>
+{% macro create_navigation(nav_items, expandable=False) %}
+  <ul class="p-side-navigation__list">
     {% for element in nav_items %}
-    <li>
+    <li class="p-side-navigation__item">
       {% if element.navlink_href %}
-        <a href="{{ element.navlink_href }}"
-          {% if request.path == element.navlink_href %}aria-current="page"{% endif %}
-        >{{ element.navlink_text }}</a>
+      <a class="p-side-navigation__link" href="{{ element.navlink_href }}"
+        {% if element.is_active %}aria-current="page"{% endif %}
+      >{{ element.navlink_text }}</a>
       {% else %}
-        <strong>{{ element.navlink_text }}</strong>
+        <strong class="p-side-navigation__text">{{ element.navlink_text }}</strong>
       {% endif %}
 
-      {% if element.children %}
-        {{ create_navigation(element.children) }}
+      {% if expandable %}
+        {% if element.navlink_href %}
+          {% if element.children and (element.is_active or element.has_active_child) %}
+            {{ create_navigation(element.children, True) }}
+          {% endif %}
+        {% else %}
+          {{ create_navigation(element.children, True) }}
+        {% endif %}
+      {% else %}
+        {% if element.children %}
+          {{ create_navigation(element.children, False) }}
+        {% endif %}
       {% endif %}
     </li>
     {% endfor %}
@@ -34,7 +44,7 @@
       <select>
       {% endif %}
 
-      <nav data-js="navigation" class="p-side-navigation--raw-html" id="{{ navigation['path'] or 'default' }}">
+      <nav data-js="navigation" class="p-side-navigation" id="{{ navigation['path'] or 'default' }}">
         <a href="#{{ navigation['path'] or 'default' }}" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
           Toggle side navigation
         </a>
@@ -46,21 +56,25 @@
             </a>
           </div>
           {% for nav_group in navigation.nav_items %}
-            {% if not nav_group.hidden %}
+          {% if not nav_group.hidden %}
+            {% if nav_group.navlink_text %}
               {% if nav_group.navlink_href %}
-                <h3>
-                  <a
-                    class="p-link--soft"
-                    href="{{ nav_group.navlink_href }}"
-                    {% if request.path == nav_group.navlink_href %}aria-current="page"{% endif %}
-                  >{{ nav_group.navlink_text }}</a>
+              <h3 class="p-side-navigation__heading--linked">
+                <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+                  {{ nav_group.navlink_text }}
+                </a>
               </h3>
-              {% elif nav_group.navlink_text %}
-                 <h3>{{ nav_group.navlink_text }}</h3>
+              {% else %}
+                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
               {% endif %}
-              {{ create_navigation(nav_group.children) }}
             {% endif %}
-          {% endfor %}
+            {#
+              Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
+              Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
+            #}
+            {{ create_navigation(nav_group.children, expandable=True) }}
+          {% endif %}
+        {% endfor %}
         </div>
       </nav>
     </aside>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,7 +1130,7 @@ nanoid@^3.1.30:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
   integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
-nanoid@^3.3.3, nanoid@^3.3.4:
+nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
@@ -1319,7 +1319,12 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
-postcss-scss@4.0.3, postcss-scss@^4.0.2:
+postcss-scss@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.4.tgz#aa8f60e19ee18259bc193db9e4b96edfce3f3b1f"
+  integrity sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==
+
+postcss-scss@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.3.tgz#36c23c19a804274e722e83a54d20b838ab4767ac"
   integrity sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==
@@ -1354,15 +1359,6 @@ postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
-
-postcss@8.4.13:
-  version "8.4.13"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.13.tgz#7c87bc268e79f7f86524235821dfdf9f73e5d575"
-  integrity sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==
-  dependencies:
-    nanoid "^3.3.3"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
 
 postcss@8.4.14, postcss@^8.4.6:
   version "8.4.14"
@@ -1515,19 +1511,19 @@ sass@1.45.2:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-sass@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.51.0.tgz#25ea36cf819581fe1fe8329e8c3a4eaaf70d2845"
-  integrity sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==
+sass@1.52.1:
+  version "1.52.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.1.tgz#554693da808543031f9423911d62c60a1acf7889"
+  integrity sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-sass@1.52.1:
-  version "1.52.1"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.1.tgz#554693da808543031f9423911d62c60a1acf7889"
-  integrity sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==
+sass@1.52.2:
+  version "1.52.2"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.2.tgz#cd1f03e0e7be5bb2cebcf1c34d735f087d790936"
+  integrity sha512-mfHB2VSeFS7sZlPv9YohB9GB7yWIgQNTGniQwfQ04EoQN0wsQEv7SwpCwy/x48Af+Z3vDeFXz+iuXM3HK/phZQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -1901,18 +1897,18 @@ vanilla-framework@3.0.1:
     postcss-cli "9.1.0"
     sass "1.45.2"
 
-vanilla-framework@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.4.0.tgz#822de5f9fff94b8cf6856f383a385f57503012d0"
-  integrity sha512-i7svPBObyt1h+nOL9ob5RSmEAq6Mupfgqnx19CqkMckzRYn+9BnrpvDyJw0GElMRt8AaNSzzJ+m3Gt06HsolFQ==
+vanilla-framework@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.5.0.tgz#966024ec79f33450103c6e93fc0cda6337003954"
+  integrity sha512-4Sd67/DDXzv1gG3eiHlwdC9BL1pI7SEorBd/lm3X6Z151di7hoU2YqCJTll+jM2pLf4DpD3cGyEYo3ueuXKoGA==
   dependencies:
     "@canonical/cookie-policy" "3.4.0"
     "@canonical/latest-news" "1.3.0"
     autoprefixer "10.4.7"
-    postcss "8.4.13"
+    postcss "8.4.14"
     postcss-cli "9.1.0"
-    postcss-scss "4.0.3"
-    sass "1.51.0"
+    postcss-scss "4.0.4"
+    sass "1.52.2"
     yaml "1.10.2"
 
 verbalize@^0.1.2:


### PR DESCRIPTION
## Done

Updates the docs template to use new expanding side navigation.

Demo: https://juju-is-414.demos.haus/docs/olm

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the docs template works as expected (it won't expand yet, because discourse navigation table hasn't been updated with nested nav items)

