### PR TITLE
Add site restricted search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.flask-base==1.0.5
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.yaml-responses==1.2.0
 canonicalwebteam.discourse==4.0.8
-canonicalwebteam.search==1.0.0
+canonicalwebteam.search==1.2.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 black==22.3.0

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -100,5 +100,7 @@ def init_docs(app):
             session=session,
             site="juju.is/docs",
             template_path="docs/search.html",
+            site_restricted_search=True,
+            search_engine_id="fdc2d22def1453cf1",
         ),
     )


### PR DESCRIPTION
## Done

Following [the set of PRs](https://github.com/canonical-web-and-design/maas.io/pull/742
) to add site restricted search to avoid reaching quota limits

## QA

- Check out this feature branch
- Run the site using the command `dotrun clean && dotrun` (new verseion of search to be installed)
- View the site locally in your web browser at: http://0.0.0.0:8041
- Search juju docs e.g. http://localhost:8041/docs/search?q=application

if you don't have the latest search API key in `.env.local` ping me