### PR TITLE
Replace "Supports" carousel with lists

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,6 @@
 <script src="{{ versioned_static('js/what-is-juju.js') }}"></script>
 <script src="{{ versioned_static('js/typer.js') }}" defer></script>
 <script>
-  initCarousel('#supports', '#supports-next', '#supports-previous');
   initCarousel('#testimonials', '#testimonials-next', '#testimonials-previous');
 </script>
 {% endblock %}

--- a/templates/partials/_juju-supports.html
+++ b/templates/partials/_juju-supports.html
@@ -5,373 +5,75 @@
     </div>
   </div>
 
-  <div class="row p-carousel">
-    <div class="col-12">
-      <a href="#" id="supports-next" class="p-carousel__next">
-        <i class="p-icon--chevron-down">Next page</i>
-      </a>
-      <a href="#" id="supports-previous" class="p-carousel__previous">
-        <i class="p-icon--chevron-down">Previous page</i>
-      </a>
-
-      <div id="supports">
-        <div class="p-carousel__cell u-vertically-center">
-          <div class="p-strip is-shallow">
-            <div class="row">
-              <div class="col-8 col-start-large-3">
-                <div class="p-card--highlighted" style="margin: 1rem;">
-                  <h3 class="p-heading--5">Public Clouds</h3>
-                  <hr />
-                  <ul class="row u-no-margin--bottom">
-                    <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      <a href="https://juju.is/docs/aws-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/f4b0487e-aws-logo.svg",
-                            alt="Amazon Web Services logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/azure-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/35e4c3fb-microsoft-azure-logo.svg",
-                            alt="Microsoft Azure logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/gce-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/57e46e3b-google-logo.svg",
-                            alt="Google Cloud logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2 col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/oci-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/62c0c762-oracle-logo.svg",
-                            alt="Oracle logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2 col-start-small-2">
-                      <a href="https://juju.is/docs/rackspace-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/50aef2d0-rackspace-logo.svg",
-                            alt="Rackspace logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="p-carousel__cell u-vertically-center">
-          <div class="p-strip is-shallow">
-            <div class="row">
-              <div class="col-8 col-start-large-3">
-                <div class="p-card--highlighted" style="margin: 1rem;">
-                  <h3 class="p-heading--5">Private Cloud</h3>
-                  <hr />
-                  <ul class="row u-no-margin--bottom">
-                    <li class="col-2 col-medium-2 col-small-2 col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/vsphere-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/bc0dcda4-vmware-logo.svg",
-                            alt="vmware logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/openstack-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/123fa920-openstack-logo.svg",
-                            alt="Openstack logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2  col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/maas-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/8dc96822-maas-logo.svg",
-                            alt="MAAS logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/manual-cloud">
-                        {{
-                          image(                        
-                            url="https://assets.ubuntu.com/v1/cf9550e3-managed-cloud-logo.svg",
-                            alt="manual cloud logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="p-carousel__cell u-vertically-center">
-          <div class="p-strip is-shallow">
-            <div class="row">
-              <div class="col-8 col-start-large-3">
-                <div class="p-card--highlighted" style="margin: 1rem;">
-                  <h3 class="p-heading--5">Kubernetes</h3>
-                  <hr />
-                  <ul class="row u-no-margin--bottom">
-                    <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      <a href="https://juju.is/docs/microk8s-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/89fdda84-microk8s-logo.svg",
-                            alt="MicroK8s logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/kubernetes/azure-aks">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/35e4c3fb-microsoft-azure-logo.svg",
-                            alt="Microsoft Azure logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      <a href="https://juju.is/docs/kubernetes/amazon-eks">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/f4b0487e-aws-logo.svg",
-                            alt="AWS logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2 col-start-medium-2 col-start-large-3">
-                      <a href="https://juju.is/docs/kubernetes/google-gke">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/57e46e3b-google-logo.svg",
-                            alt="Google Cloud logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2 col-start-small-2">
-                      <a href="https://juju.is/docs/kubernetes">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/d789eb54-k8s-logo.svg",
-                            alt="Kubernetes logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="p-carousel__cell u-vertically-center">
-          <div class="p-strip is-shallow">
-            <div class="row">
-              <div class="col-8 col-start-large-3">
-                <div class="p-card--highlighted" style="margin: 1rem;">
-                  <h3 class="p-heading--5">Localhost</h3>
-                  <hr />
-                  <ul class="row u-no-margin--bottom">
-                    <li class="col-2 col-medium-2 col-small-2 col-start-large-4 col-start-medium-3 col-start-small-2">
-                      <a href="https://juju.is/docs/lxd-cloud">
-                        {{
-                          image(
-                            url="https://assets.ubuntu.com/v1/73d1829d-lxd-logo.svg",
-                            alt="LXD logo",
-                            height="144",
-                            width="145",
-                            hi_def=True,
-                            loading="eager",
-                          ) | safe
-                        }}
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="p-carousel__cell u-vertically-center">
-          <div class="p-strip is-shallow">
-            <div class="row">
-              <div class="col-8 col-start-large-3">
-                <div class="p-card--highlighted" style="margin: 1rem;">
-                  <h3 class="p-heading--5">Operators</h3>
-                  <hr />
-                  <ul class="row u-no-margin--bottom u-align-text--center">
-                    <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      {{
-                        image(
-                          url="https://assets.ubuntu.com/v1/d789eb54-k8s-logo.svg",
-                          alt="k8s logo",
-                          height="144",
-                          width="145",
-                          hi_def=True,
-                          loading="eager",
-                        ) | safe
-                      }}
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      {{
-                        image(
-                          url="https://assets.ubuntu.com/v1/e26901ed-linux-logo.svg",
-                          alt="Linux logo",
-                          height="144",
-                          width="145",
-                          hi_def=True,
-                          loading="eager",
-                        ) | safe
-                      }}
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      {{
-                        image(
-                          url="https://assets.ubuntu.com/v1/70655b4b-windows-logo.svg",
-                          alt="Windows logo",
-                          height="144",
-                          width="145",
-                          hi_def=True,
-                          loading="eager",
-                        ) | safe
-                      }}
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2 col-start-large-2">
-                      {{
-                        image(
-                          url="https://assets.ubuntu.com/v1/b88d48be-saas-logo.svg",
-                          alt="saas logo",
-                          height="144",
-                          width="145",
-                          hi_def=True,
-                          loading="eager",
-                        ) | safe
-                      }}
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      {{
-                        image(
-                          url="https://assets.ubuntu.com/v1/27c4bde6-appliance-logo.svg",
-                          alt="physical appliance logo",
-                          height="144",
-                          width="145",
-                          hi_def=True,
-                          loading="eager",
-                        ) | safe
-                      }}
-                    </li>
-                    <li class="col-2 col-medium-2 col-small-2">
-                      {{
-                        image(
-                          url="https://assets.ubuntu.com/v1/9af66a46-software-logo.svg",
-                          alt="uncharmed software logo",
-                          height="144",
-                          width="145",
-                          hi_def=True,
-                          loading="eager",
-                        ) | safe
-                      }}
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+  <div class="row p-divider">
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--5">Public Clouds</h3>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/aws-cloud">Amazon AWS</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/azure-cloud">Microsoft Azure</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/gce-cloud">Google GCE</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/oci-cloud">Oracle</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/olm/equinix-metal">Equnix Metal</a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--5">Private Cloud</h3>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/vsphere-cloud">VMware vSphere</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/openstack-cloud">OpenStack</a>
+        </li>
+        <li class="col-2 col-medium-2 col-small-2  col-start-medium-2 col-start-large-3">
+          <a href="https://juju.is/docs/maas-cloud">MAAS</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/manual-cloud">Manual cloud</a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--5">Kubernetes</h3>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/microk8s-cloud">MicroK8s</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/kubernetes/azure-aks">Azure AKS</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/kubernetes/amazon-eks">Amazon EKS</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/kubernetes/google-gke">Google GKE</a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--5">Localhost</h3>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="https://juju.is/docs/lxd-cloud">LXD</a>
+        </li>
+      </ul>
     </div>
   </div>
-</section>
+  
+
+                  
+
+                  
+
+                  
+                  


### PR DESCRIPTION
## Done

- Replaced the carousel in the "Juju supports" section with a list of links that uses the Vanilla divider pattern, according to the request in the copy doc: https://docs.google.com/document/d/147spDkSVH0YaEGKZ4tDi7i28zzhIcacF1hBOMHvxaC0/edit?disco=AAAAayFi0G4

## QA

- View the site in your web browser at: https://juju-is-419.demos.haus/
- Scroll down to the "Juju supports" section, see that it matches Spencer's [design](https://github.com/canonical-web-and-design/web-squad/issues/5500#issuecomment-1155341660)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5500
