### PR TITLE
Add operator day videos for May to /operator-day

### DIFF
--- a/templates/operator-day/index.html
+++ b/templates/operator-day/index.html
@@ -6,13 +6,199 @@
 
 {% block content %}
 
-<section class="p-strip">
-  <div class="u-fixed-width">
+<section class="p-strip is-shallow">
+  <div class="u-fixed-width u-sv3">
     <h1>Operator Day</h1>
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip is-bordered">
+  <div class="u-fixed-width u-sv3">
+    <h2>May 2022</h2>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=kHG_nCSv51s">Plenary session with Mark Shuttleworth and David Booth</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/kHG_nCSv51s?controls=0"
+          title="Plenary session with Mark Shuttleworth and David Booth"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=rV_Su4QDpOk">A common substrate for enabling solutions with Alex Jones</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/rV_Su4QDpOk?controls=0"
+          title="A common substrate for enabling solutions with Alex Jones"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=602N4MCaMvs">Juju & Charmed Ecosystem Update with Jon Seager</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/602N4MCaMvs?controls=0"
+          title="Juju & Charmed Ecosystem Update with Jon Seager"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=vj0NUixg-Tg">30 mins to stand up a simple app with Daniela Plascencia</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/vj0NUixg-Tg?controls=0"
+          title="30 mins to stand up a simple app with Daniela Plascencia"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=PEJc-SfEFt8">Observability for developers of Charmed Operators with Simon Aronsson</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/PEJc-SfEFt8?controls=0"
+          title="Observability for developers of Charmed Operators with Simon Aronsson"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=MT4y6bYyX0o">Testing framework for Juju Charmed Operators with Marc Oppenheimer</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/MT4y6bYyX0o?controls=0"
+          title="Testing framework for Juju Charmed Operators with Marc Oppenheimer"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=8ozNW-rJXj8">Publishing Charmed Operators with Michael Jaeger and Pedro Leão Da Cruz</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/8ozNW-rJXj8?controls=0"
+          title="Publishing Charmed Operators with Michael Jaeger and Pedro Leão Da Cruz"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=XP-wmLOQsuU">Building a sophisticated product on Juju with Rob Gibbon</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/XP-wmLOQsuU?controls=0"
+          title="Building a sophisticated product on Juju with Rob Gibbon"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="col-8">
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=ac5d5dHDVmE">Experts Panel Discussion: Outlook to Kubernetes and cloud native operations</a></h3>
+    </div>
+
+    <div class="col-4">
+      <div class="u-embedded-media u-hide--small">
+        <iframe
+          width="560"
+          height="340"
+          src="https://www.youtube.com/embed/ac5d5dHDVmE?controls=0"
+          title="Experts Panel Discussion: Outlook to Kubernetes and cloud native operations"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>  
+</section>
+
+<section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>October 2021</h2>
   </div>
@@ -26,7 +212,7 @@
       <div class="u-embedded-media u-hide--small">
         <iframe
           width="560"
-          height="302"
+          height="340"
           src="https://www.youtube.com/embed/uWFC1_DeIZU?controls=0"
           title="KubeCon NA 2021: Operator Day Keynote with Mark Shuttleworth"
           frameborder="0"
@@ -36,8 +222,10 @@
       </div>
     </div>
   </div>
+</section>
 
-  <div class="u-fixed-width">
+<section class="p-strip">
+  <div class="u-fixed-width u-sv3">
     <h2>May 2021</h2>
   </div>
 
@@ -50,7 +238,7 @@
       <div class="u-embedded-media u-hide--small">
         <iframe
           width="560"
-          height="302"
+          height="340"
           src="https://www.youtube.com/embed/jDvQrcFE32g?controls=0"
           title="KubeCon Operator Day keynote with Mark Shuttleworth"
           frameborder="0"
@@ -63,14 +251,14 @@
 
   <div class="row">
     <div class="col-8">
-      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=yxeJX2WRYjg">How to build a Charmed Operator for Kubernetes</a></h3>
+      <h3 class="p-heading--4"><a href="https://www.youtube.com/watch?v=yxeJX2WRYjg">How to build a Charmed Operator for Kubernetes with Jon Seager</a></h3>
     </div>
 
     <div class="col-4">
       <div class="u-embedded-media u-hide--small">
         <iframe
           width="560"
-          height="302"
+          height="340"
           src="https://www.youtube.com/embed/yxeJX2WRYjg?controls=0"
           title="How to build a Charmed Operator for Kubernetes"
           frameborder="0"


### PR DESCRIPTION
## Done

**Note: the page is currently a little dry and will need a visual update, this is being tracked here https://github.com/canonical-web-and-design/ubuntu.com/issues/11797**
Add operator day videos for May to /operator-day



## QA

- Go to https://juju-is-423.demos.haus//operator-day and compare against [copydoc](https://docs.google.com/document/d/1ZFRGkZ4vvvMVOgq4MIsBuebHsA7Y0rTyiZ76qjQpOAg/edit#)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5610