### PR TITLE
Display all posts on the blog index page

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -35,7 +35,7 @@
 
   <div class="row u-clearfix">
     {% for article in articles %}
-      {% if loop.index >= 4 %}
+      {% if loop.index >= 3 %}
         {% include 'blog/partials/_blog-card.html' %}
       {% endif %}
     {% endfor %}
@@ -53,7 +53,7 @@
     <nav class="p-pagination" aria-label="Pagination">
 
       <ol class="p-pagination__items u-align--center">
-  
+
         {% if current_page > 1 %}
           <li class="p-pagination__item">
             <a class="p-pagination__link--previous" href="/blog?page={{ current_page - 1 }}" title="Previous page">
@@ -65,61 +65,61 @@
             <span class="p-pagination__link--previous is-disabled"><i class="p-icon--chevron-down">Previous page</i></span>
           </li>
         {% endif %}
-  
+
         {# always show 5 pages in pagination #}
         {% if current_page > 4 and current_page == total_pages %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page - 4 }}">{{ current_page - 4 }}</a>
           </li>
         {% endif %}
-  
+
         {% if current_page > 3 and current_page >= total_pages - 1 %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page - 3 }}">{{ current_page - 3 }}</a>
           </li>
         {% endif %}
-  
+
         {% if current_page > 2 %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page - 2 }}">{{ current_page - 2 }}</a>
           </li>
         {% endif %}
-  
+
         {% if current_page > 1 %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page - 1 }}">{{ current_page - 1 }}</a>
           </li>
         {% endif %}
-  
+
         <!-- current page -->
         <li class="p-pagination__item">
           <a class="p-pagination__link is-active" href="/blog?page={{ current_page }}">{{ current_page }}</a>
         </li>
-  
+
         {% if current_page < total_pages %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page + 1 }}">{{ current_page + 1 }}</a>
           </li>
         {% endif %}
-  
+
         {% if current_page < total_pages - 1 %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page + 2 }}">{{ current_page + 2 }}</a>
           </li>
         {% endif %}
-  
+
         {% if current_page < total_pages - 2 and current_page <= 2 %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page + 3 }}">{{ current_page + 3 }}</a>
           </li>
         {% endif %}
-  
+
         {% if current_page < total_pages - 3 and current_page == 1 %}
           <li class="p-pagination__item">
             <a class="p-pagination__link" href="/blog?page={{ current_page + 4 }}">{{ current_page + 4 }}</a>
           </li>
         {% endif %}
-  
+
         {% if current_page != total_pages %}
           <li class="p-pagination__item">
             <a class="p-pagination__link--next" href="/blog?page={{ current_page + 1 }}" title="Next page">


### PR DESCRIPTION
## Done
Updated the starting index of the none highlighted posts. 

## QA

- Go to /blog
- Check that you can see the post titled: "Operator Day at Kubecon EU 2022 – recordings available!"
- Check on live its missing


## Issue / Card
Fixes https://github.com/canonical-web-and-design/juju.is/issues/396

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/180296636-f1be4f94-cd7a-400f-87be-4fa56fbad3c7.png) | ![image](https://user-images.githubusercontent.com/1413534/180296542-4797e5ac-d09d-4d04-a716-f8043dedb671.png)
