### PR TITLE
fix: docs footer

### DIFF
--- a/templates/partials/_juju-ecosystem-docs-footer.html
+++ b/templates/partials/_juju-ecosystem-docs-footer.html
@@ -11,9 +11,7 @@
               <br>
               <a href="https://matrix.to/#/#charmhub:ubuntu.com">Ask a question on Matrix</a>
               <br>
-              <a href="https://github.com/juju/juju/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument:%20index.md">Open a GitHub issue for this page</a>
-              <br>
-              <a href="https://github.com/juju/juju/edit/main/docs/index.md">Edit this page on GitHub</a>
+              <a href="https://github.com/canonical/juju.is/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument:%20index.md">Open a GitHub issue for this page</a>
             </p>
           </div>
           <div class="col-6">


### PR DESCRIPTION
## Done
- Removed "edit this page on github" as it's no longer relevant
- Updated the create issue link to point to this repo

## QA

- View https://juju-is-583.demos.haus/docs
- Try the footer links


## Issue / Card

Fixes #582 

## Screenshots

[if relevant, include a screenshot]
