### PR TITLE
Remove pylibjuju from ecosystem docs search

### DIFF
--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -567,7 +567,7 @@
         </div>
 
         <div class="grid-col-4">
-          <a href="https://pythonlibjuju.readthedocs.io/en/latest/">Python libjuju docs</a>
+          <a href="https://pythonlibjuju.readthedocs.io/en/latest/">Python Libjuju docs</a>
         </div>
       </div>
   </section>     

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -41,7 +41,7 @@
             <a href="{{ result.url }}" target="_blank">
               {{ result.title }}
             </a>&nbsp;
-            {% set search_path = "search.html" if result.domain in ["pythonlibjuju.readthedocs.io", "ops.readthedocs.io"]
+            {% set search_path = "search.html" if result.domain == "ops.readthedocs.io"
             else "search/" %}
             <a href="{{ result.search_url }}" target="_blank" class="p-chip is-inline">
               <span class="p-chip__value">{{ result.project_name }}</span>

--- a/webapp/docs/search.py
+++ b/webapp/docs/search.py
@@ -15,7 +15,6 @@ RTD_PROJECTS_HOSTED = [
 ]
 
 RTD_PROJECTS_IO = {
-    "pythonlibjuju": "https://pythonlibjuju.readthedocs.io/_/api/v3/search/",
     "ops": "https://ops.readthedocs.io/_/api/v3/search/",
 }
 
@@ -41,14 +40,6 @@ DOMAIN_INFO = {
         "search_url": (
             "https://documentation.ubuntu.com/"
             "terraform-provider-juju/latest/search/?q={query}"
-        ),
-    },
-    "pythonlibjuju.readthedocs.io": {
-        "title": "Python Libjuju",
-        "weight": 0.3,
-        "search_url": (
-            "https://pythonlibjuju.readthedocs.io/en/latest/search.html"
-            "?q={query}"
         ),
     },
     "documentation.ubuntu.com/jaas": {
@@ -81,7 +72,7 @@ def extract_full_domain(result):
     hostname = parsed_url.hostname or ""
 
     # Skip path prefix for non-Canonical hosted RTD projects
-    if hostname in ("ops.readthedocs.io", "pythonlibjuju.readthedocs.io"):
+    if hostname == "ops.readthedocs.io":
         return hostname
 
     # For Canonical docs (e.g. documentation.ubuntu.com/juju)
@@ -136,7 +127,7 @@ def search_all_docs(query):
             fetch_search_results, RTD_HOSTED_API, query, RTD_PROJECTS_HOSTED
         )
 
-        # Separate requests for pythonlibjuju and ops
+        # Separate requests for ops
         future_io = {
             project: executor.submit(
                 fetch_search_results, url, f"{project} {query}"


### PR DESCRIPTION
## Done

- Removes pylibjuju from ecosystem docs search due to new Jubilant docs

## QA

- Check the [demo](https://juju-is-592.demos.haus/docs)
- Search for something (i.e. "controller")
- Make sure Python Libjuju results don't show
- Search for something jubilant-related (i.e. "jubilant")
- Make sure Jubilant results show

## Issue / Card

Fixes [WD-26288](https://warthogs.atlassian.net/browse/WD-26288)


[WD-26288]: https://warthogs.atlassian.net/browse/WD-26288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ