### PR TITLE
docs: rename manual to unmanaged, drop equinix

### DIFF
--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -151,30 +151,30 @@
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gke-cloud-and-juju">Google
                 GKE</a>
-            </p>
-            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju">LXD</a>&nbsp;&nbsp;&nbsp;
+            </p>
+            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
                <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>
-            </p>
-            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/#cloud-kubernetes-aks">Microsoft
                 AKS</a>&nbsp;&nbsp;&nbsp;
-              <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
-                Azure</a>&nbsp;&nbsp;&nbsp;
             </p>
             <p class="p-text--small">
               <a
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
+                Azure</a>&nbsp;&nbsp;&nbsp;
+              <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>&nbsp;&nbsp;&nbsp;
+            </p>
+            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju">Oracle OCI</a>&nbsp;&nbsp;&nbsp;
               <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju/#cloud-manual">Unmanaged</a>&nbsp;&nbsp;&nbsp;
+                href="https://documentation.ubuntu.com/juju/latest/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju">Unmanaged</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/#cloud-vsphere">VMware vSphere</a>
             </p>

--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -157,8 +157,6 @@
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju">LXD</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
-              <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju/#cloud-manual">Unmanaged</a>&nbsp;&nbsp;&nbsp;
                <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>
             </p>
@@ -175,6 +173,8 @@
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju">Oracle OCI</a>&nbsp;&nbsp;&nbsp;
+              <a
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju/#cloud-manual">Unmanaged</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/#cloud-vsphere">VMware vSphere</a>
             </p>

--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -146,9 +146,6 @@
             </p>
             <p class="p-text--small">
               <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-equinix-metal-cloud-and-juju">Equinix
-                Metal</a>&nbsp;&nbsp;&nbsp;
-              <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju">Google
                 GCE</a>&nbsp;&nbsp;&nbsp;
               <a
@@ -161,7 +158,7 @@
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
               <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju/#cloud-manual">Manual</a>&nbsp;&nbsp;&nbsp;
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju/#cloud-manual">Unmanaged</a>&nbsp;&nbsp;&nbsp;
                <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>
             </p>
@@ -394,7 +391,7 @@
         <div class="p-equal-height-row__item">
           <div class="p-media-container">
             <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-flask/">
-              <img 
+              <img
                 src="https://assets.ubuntu.com/v1/d7f7f82e-Flask.svg"
                 alt="build charms with charmcraft flask"
                 class="highlighted-image">
@@ -414,7 +411,7 @@
         <div class="p-equal-height-row__item">
           <div class="p-media-container">
             <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-django/">
-              <img 
+              <img
                 src="https://assets.ubuntu.com/v1/e72692a9-Django.svg"
                 alt="build charms with charmcraft django"
                 class="highlighted-image">
@@ -435,7 +432,7 @@
           <div class="p-media-container">
             <a
               href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-fastapi/">
-              <img 
+              <img
                 src="https://assets.ubuntu.com/v1/aab84d59-FastAPI.svg"
                 alt="build charms with charmcraft fast api"
                 class="highlighted-image">
@@ -456,8 +453,8 @@
           <div class="p-media-container">
             <a
               href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-go/">
-              <img 
-                src="https://assets.ubuntu.com/v1/30e29413-GO.svg" 
+              <img
+                src="https://assets.ubuntu.com/v1/30e29413-GO.svg"
                 alt="build charms with charmcraft go"
                 class="highlighted-image">
             </a>
@@ -570,7 +567,7 @@
           <a href="https://pythonlibjuju.readthedocs.io/en/latest/">Python Libjuju docs</a>
         </div>
       </div>
-  </section>     
+  </section>
 </main>
 
 {% include "partials/_juju-ecosystem-docs-footer.html" %}


### PR DESCRIPTION
When Juju 4 is released (some time in the next two weeks), the juju.is/docs page (now https://canonical.com/juju/docs) needs to be updated as follows:

- Equinix needs to be dropped (it's no longer supported (or available, for that matter))
- Manual needs to be renamed to "Unmanaged (the changes in the code haven't been made yet, and might end up not being made, but for now the plan is that they will be made, so this PR anticipates that)

This PR makes both these changes.

Note: The line alignment might have to be adjusted in light of Equinix going away.